### PR TITLE
refactor: rename package from gong-mcp to gongio-mcp

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency:
 permissions: {}
 jobs:
   release-please:
-    if: github.repository == 'JustinBeckwith/gong-mcp'
+    if: github.repository == 'JustinBeckwith/gongio-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document provides guidance for AI agents working on this codebase.
 
 ## Project Overview
 
-**gong-mcp** is an MCP (Model Context Protocol) server that provides access to Gong.io data. It allows MCP-compatible clients like Claude Desktop to query calls, retrieve transcripts, and list users from Gong.
+**gongio-mcp** is an MCP (Model Context Protocol) server that provides access to Gong.io data. It allows MCP-compatible clients like Claude Desktop to query calls, retrieve transcripts, and list users from Gong.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ An MCP (Model Context Protocol) server that provides access to your Gong.io data
 ### From npm
 
 ```bash
-npm install -g gong-mcp
+npm install -g gongio-mcp
 ```
 
 ### From source
 
 ```bash
-git clone https://github.com/your-username/gong-mcp.git
-cd gong-mcp
+git clone https://github.com/your-username/gongio-mcp.git
+cd gongio-mcp
 npm install
 npm run build
 ```
@@ -55,7 +55,7 @@ export GONG_ACCESS_KEY_SECRET="your-secret-key"
 ### Running the Server
 
 ```bash
-gong-mcp
+gongio-mcp
 # or if installed locally:
 npm start
 ```
@@ -69,7 +69,7 @@ Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/
   "mcpServers": {
     "gong": {
       "command": "npx",
-      "args": ["gong-mcp"],
+      "args": ["gongio-mcp"],
       "env": {
         "GONG_ACCESS_KEY": "your-access-key",
         "GONG_ACCESS_KEY_SECRET": "your-secret-key"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "gong-mcp",
+	"name": "gongio-mcp",
 	"version": "1.0.0",
 	"description": "MCP server for Gong.io - access calls, transcripts, and users",
-	"mcpName": "io.github.JustinBeckwith/gong-mcp",
+	"mcpName": "io.github.JustinBeckwith/gongio-mcp",
 	"type": "module",
 	"main": "dist/index.js",
 	"bin": {
-		"gong-mcp": "dist/index.js"
+		"gongio-mcp": "dist/index.js"
 	},
 	"files": [
 		"dist"
@@ -38,12 +38,12 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/JustinBeckwith/gong-mcp.git"
+		"url": "https://github.com/JustinBeckwith/gongio-mcp.git"
 	},
 	"bugs": {
-		"url": "https://github.com/JustinBeckwith/gong-mcp/issues"
+		"url": "https://github.com/JustinBeckwith/gongio-mcp/issues"
 	},
-	"homepage": "https://github.com/JustinBeckwith/gong-mcp#readme",
+	"homepage": "https://github.com/JustinBeckwith/gongio-mcp#readme",
 	"engines": {
 		"node": ">=18.0.0"
 	},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
 	"packages": {
 		".": {
 			"release-type": "node",
-			"package-name": "gong-mcp",
+			"package-name": "gongio-mcp",
 			"changelog-path": "CHANGELOG.md",
 			"extra-files": [
 				"package.json",

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "io.github.JustinBeckwith/gong-mcp",
+  "name": "io.github.JustinBeckwith/gongio-mcp",
   "description": "MCP server for Gong.io - access calls, transcripts, and users",
   "repository": {
-    "url": "https://github.com/JustinBeckwith/gong-mcp",
+    "url": "https://github.com/JustinBeckwith/gongio-mcp",
     "source": "github"
   },
   "version": "1.0.0",
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "gong-mcp",
+      "identifier": "gongio-mcp",
       "version": "1.0.0",
       "transport": {
         "type": "stdio"

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const gong = new GongClient({
 
 const server = new Server(
   {
-    name: "gong-mcp",
+    name: "gongio-mcp",
     version: "1.0.0",
   },
   {


### PR DESCRIPTION
## Summary
The name `gong-mcp` was already taken on npm (v2.9.0 exists). Renamed to `gongio-mcp`.

Updated:
- package.json (name, mcpName, bin, repository URLs)
- server.json (name, identifier, repository URL)
- release-please-config.json
- release.yaml workflow
- README.md
- AGENTS.md
- src/index.ts server name

## Test plan
- [x] `pnpm run validate:mcp` passes
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)