### PR TITLE
feat: add Zod validation and two-tier tool approach

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,0 +1,208 @@
+/**
+ * Formatters to convert API responses to markdown tables
+ * Reduces token usage compared to JSON output
+ */
+
+import type {
+	CallsResponse,
+	CallDetails,
+	CallTranscript,
+	UsersResponse,
+} from './schemas.js';
+
+// Party type for speaker name resolution
+interface Party {
+	id?: string | null;
+	name?: string | null;
+	emailAddress?: string | null;
+	speakerId?: string | null;
+	affiliation?: string | null;
+}
+
+/**
+ * Format calls list as markdown table
+ */
+export function formatCallsResponse(response: CallsResponse): string {
+	const lines: string[] = [];
+
+	lines.push(`**Calls** (${response.records.totalRecords} total)\n`);
+
+	if (response.calls.length === 0) {
+		lines.push('No calls found.');
+		return lines.join('\n');
+	}
+
+	lines.push('| ID | Title | Date | Duration | Scope |');
+	lines.push('|---|---|---|---|---|');
+
+	for (const call of response.calls) {
+		const date = call.started
+			? new Date(call.started).toLocaleDateString()
+			: '-';
+		const duration = call.duration
+			? `${Math.round(call.duration / 60)}m`
+			: '-';
+		const title = call.title?.slice(0, 50) ?? '-';
+		lines.push(
+			`| ${call.id} | ${escapeMarkdown(title)} | ${date} | ${duration} | ${call.scope ?? '-'} |`,
+		);
+	}
+
+	if (response.records.cursor) {
+		lines.push(`\n*More results available. Cursor:* \`${response.records.cursor}\``);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Format a single call summary (compact, key info only)
+ */
+export function formatCallSummary(call: CallDetails): string {
+	const lines: string[] = [];
+	const meta = call.metaData;
+
+	lines.push(`## ${escapeMarkdown(meta.title ?? 'Untitled Call')}\n`);
+
+	// Compact metadata
+	const metaParts: string[] = [`**ID:** ${meta.id}`];
+	if (meta.started) {
+		metaParts.push(`**Date:** ${new Date(meta.started).toLocaleString()}`);
+	}
+	if (meta.duration) {
+		metaParts.push(`**Duration:** ${Math.round(meta.duration / 60)}m`);
+	}
+	if (meta.scope) {
+		metaParts.push(`**Scope:** ${meta.scope}`);
+	}
+	lines.push(metaParts.join(' | '));
+	if (meta.url) {
+		lines.push(`**URL:** ${meta.url}`);
+	}
+
+	// Participants (compact)
+	if (call.parties && call.parties.length > 0) {
+		lines.push('\n### Participants\n');
+		const participants = call.parties.map((p) => {
+			const name = p.name ?? p.emailAddress ?? 'Unknown';
+			const role = p.affiliation ? ` (${p.affiliation})` : '';
+			return `${escapeMarkdown(name)}${role}`;
+		});
+		lines.push(participants.join(', '));
+	}
+
+	// Brief summary (most important)
+	if (call.content?.brief) {
+		lines.push('\n### Summary\n');
+		lines.push(escapeMarkdown(call.content.brief));
+	}
+
+	// Key Points
+	if (call.content?.keyPoints && call.content.keyPoints.length > 0) {
+		lines.push('\n### Key Points\n');
+		for (const point of call.content.keyPoints) {
+			lines.push(`- ${escapeMarkdown(point.text)}`);
+		}
+	}
+
+	// Action Items
+	if (call.content?.pointsOfInterest?.actionItems?.length) {
+		lines.push('\n### Action Items\n');
+		for (const item of call.content.pointsOfInterest.actionItems) {
+			if (item.snippet) {
+				lines.push(`- ${escapeMarkdown(item.snippet)}`);
+			}
+		}
+	}
+
+	// Topics (compact)
+	if (call.content?.topics && call.content.topics.length > 0) {
+		lines.push('\n### Topics\n');
+		const topics = call.content.topics.map(
+			(t) => `${escapeMarkdown(t.name)} (${Math.round(t.duration / 60)}m)`,
+		);
+		lines.push(topics.join(', '));
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Format a single call transcript with speaker names
+ */
+export function formatCallTranscript(
+	transcript: CallTranscript,
+	parties?: Party[] | null,
+): string {
+	const lines: string[] = [];
+
+	// Build speaker ID to name mapping
+	const speakerNames = new Map<string, string>();
+	if (parties) {
+		for (const party of parties) {
+			if (party.speakerId) {
+				const name = party.name ?? party.emailAddress ?? `Speaker ${party.speakerId}`;
+				speakerNames.set(party.speakerId, name);
+			}
+		}
+	}
+
+	lines.push(`## Transcript (Call ${transcript.callId})\n`);
+
+	if (transcript.transcript.length === 0) {
+		lines.push('*No transcript available*');
+		return lines.join('\n');
+	}
+
+	for (const entry of transcript.transcript) {
+		const speakerName = speakerNames.get(entry.speakerId) ?? `Speaker ${entry.speakerId}`;
+		const text = entry.sentences.map((s) => s.text).join(' ');
+		lines.push(`[${escapeMarkdown(speakerName)}]: ${escapeMarkdown(text)}\n`);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Format users list as markdown table
+ */
+export function formatUsersResponse(response: UsersResponse): string {
+	const lines: string[] = [];
+
+	lines.push(`**Users** (${response.records.totalRecords} total)\n`);
+
+	if (response.users.length === 0) {
+		lines.push('No users found.');
+		return lines.join('\n');
+	}
+
+	lines.push('| ID | Name | Email | Title | Active |');
+	lines.push('|---|---|---|---|---|');
+
+	for (const user of response.users) {
+		const name =
+			[user.firstName, user.lastName].filter(Boolean).join(' ') || '-';
+		const email = user.emailAddress ?? '-';
+		const title = user.title?.slice(0, 30) ?? '-';
+		const active = user.active ? 'Yes' : 'No';
+		lines.push(
+			`| ${user.id} | ${escapeMarkdown(name)} | ${email} | ${escapeMarkdown(title)} | ${active} |`,
+		);
+	}
+
+	if (response.records.cursor) {
+		lines.push(`\n*More results available. Cursor:* \`${response.records.cursor}\``);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Escape markdown special characters in text
+ */
+function escapeMarkdown(text: string): string {
+	return text
+		.replace(/\|/g, '\\|')
+		.replace(/\n/g, ' ')
+		.replace(/\r/g, '');
+}

--- a/src/gong.ts
+++ b/src/gong.ts
@@ -3,6 +3,19 @@
  * https://gong.app.gong.io/settings/api/documentation
  */
 
+import {
+	type CallsResponse,
+	type CallDetailsResponse,
+	type TranscriptsResponse,
+	type UsersResponse,
+	type ListCallsRequest,
+	type ListUsersRequest,
+	parseCallsResponse,
+	parseCallDetailsResponse,
+	parseTranscriptsResponse,
+	parseUsersResponse,
+} from './schemas.js';
+
 const GONG_API_BASE = 'https://api.gong.io/v2';
 
 export interface GongConfig {
@@ -10,236 +23,18 @@ export interface GongConfig {
 	accessKeySecret: string;
 }
 
-export interface Call {
-	id: string;
-	title: string;
-	scheduled: string;
-	started: string;
-	duration: number;
-	primaryUserId: string;
-	direction: string;
-	scope: string;
-	media: string;
-	language: string;
-	workspaceId: string;
-	url: string;
-}
-
-export interface CallsResponse {
-	requestId: string;
-	records: {
-		cursor?: string;
-		totalRecords: number;
-		currentPageSize: number;
-		currentPageNumber: number;
-	};
-	calls: Call[];
-}
-
-export interface TranscriptEntry {
-	speakerId: string;
-	topic: string;
-	sentences: {
-		start: number;
-		end: number;
-		text: string;
-	}[];
-}
-
-export interface CallTranscript {
-	callId: string;
-	transcript: TranscriptEntry[];
-}
-
-export interface TranscriptsResponse {
-	requestId: string;
-	records: {
-		cursor?: string;
-		totalRecords: number;
-		currentPageSize: number;
-		currentPageNumber: number;
-	};
-	callTranscripts: CallTranscript[];
-}
-
-export interface User {
-	id: string;
-	emailAddress: string;
-	created: string;
-	active: boolean;
-	emailAliases: string[];
-	trustedEmailAddress: string;
-	firstName: string;
-	lastName: string;
-	title: string;
-	phoneNumber: string;
-	extension: string;
-	personalMeetingUrls: string[];
-	settings: {
-		webConferencesRecorded: boolean;
-		preventWebConferenceRecording: boolean;
-		telephonyCallsRecorded: boolean;
-		emailsRecorded: boolean;
-		preventEmailRecording: boolean;
-		nonRecordedMeetingsDefaultPrivacy: string;
-		gpiSettings: unknown;
-		emailsImported: boolean;
-	};
-	managerId: string;
-	meetingConsentPageUrl: string;
-	spokenLanguages: {
-		language: string;
-		primary: boolean;
-	}[];
-}
-
-export interface UsersResponse {
-	requestId: string;
-	records: {
-		cursor?: string;
-		totalRecords: number;
-		currentPageSize: number;
-		currentPageNumber: number;
-	};
-	users: User[];
-}
-
-export interface CallDetails {
-	metaData: {
-		id: string;
-		url: string;
-		title: string;
-		scheduled: string;
-		started: string;
-		duration: number;
-		primaryUserId: string;
-		direction: string;
-		system: string;
-		scope: string;
-		media: string;
-		language: string;
-		workspaceId: string;
-		sdrDisposition: string;
-		clientUniqueId: string;
-		customData: string;
-		purpose: string;
-		meetingUrl: string;
-		isPrivate: boolean;
-		calendarEventId: string;
-	};
-	context: Array<{
-		system: string;
-		objects: Array<{
-			objectType: string;
-			objectId: string;
-			fields: Array<{ name: string; value: string }>;
-			timing: string;
-		}>;
-	}>;
-	parties: Array<{
-		id: string;
-		emailAddress: string;
-		name: string;
-		title: string;
-		userId: string;
-		speakerId: string;
-		context: Array<{
-			system: string;
-			objects: Array<{
-				objectType: string;
-				objectId: string;
-				fields: Array<{ name: string; value: string }>;
-			}>;
-		}>;
-		affiliation: string;
-		phoneNumber: string;
-		methods: string[];
-	}>;
-	content: {
-		trackers: Array<{
-			id: string;
-			name: string;
-			count: number;
-			type: string;
-			occurrences: Array<{
-				startTime: number;
-				speakerId: string;
-			}>;
-		}>;
-		topics: Array<{
-			name: string;
-			duration: number;
-		}>;
-		pointsOfInterest: {
-			actionItems: Array<{
-				snippetStartTime: number;
-				snippetEndTime: number;
-				speakerIds: string[];
-				snippet: string;
-			}>;
-		};
-		brief: string;
-		outline: Array<{
-			section: string;
-			startTime: number;
-			duration: number;
-			items: Array<{
-				text: string;
-				startTime: number;
-			}>;
-		}>;
-		callOutcome: {
-			id: string;
-			category: string;
-			name: string;
-		};
-		keyPoints: Array<{
-			text: string;
-		}>;
-	};
-	interaction: {
-		speakers: Array<{
-			id: string;
-			visibility: number;
-			talkTime: number;
-		}>;
-		interactivity: number;
-		video: Array<{
-			name: string;
-			duration: number;
-		}>;
-		questions: {
-			companyCount: number;
-			nonCompanyCount: number;
-		};
-	};
-	collaboration: {
-		publicComments: Array<{
-			id: string;
-			audioStartTime: number;
-			audioEndTime: number;
-			commenterUserId: string;
-			comment: string;
-			posted: string;
-			inReplyTo: string;
-			duringCall: boolean;
-		}>;
-	};
-	media: {
-		audioUrl: string;
-		videoUrl: string;
-	};
-}
-
-export interface CallDetailsResponse {
-	requestId: string;
-	records: {
-		totalRecords: number;
-		currentPageSize: number;
-		currentPageNumber: number;
-	};
-	calls: CallDetails[];
-}
+// Re-export types from schemas
+export type {
+	Call,
+	CallsResponse,
+	CallDetails,
+	CallDetailsResponse,
+	CallTranscript,
+	TranscriptEntry,
+	TranscriptsResponse,
+	User,
+	UsersResponse,
+} from './schemas.js';
 
 export class GongClient {
 	private authHeader: string;
@@ -309,12 +104,7 @@ export class GongClient {
 	/**
 	 * List calls with optional filtering (GET /v2/calls)
 	 */
-	async listCalls(options?: {
-		fromDateTime?: string;
-		toDateTime?: string;
-		workspaceId?: string;
-		cursor?: string;
-	}): Promise<CallsResponse> {
+	async listCalls(options?: ListCallsRequest): Promise<CallsResponse> {
 		const params: Record<string, string> = {};
 
 		if (options?.fromDateTime) {
@@ -330,7 +120,8 @@ export class GongClient {
 			params.cursor = options.cursor;
 		}
 
-		return this.get<CallsResponse>('/calls', params);
+		const response = await this.get('/calls', params);
+		return parseCallsResponse(response);
 	}
 
 	/**
@@ -342,7 +133,8 @@ export class GongClient {
 				callIds,
 			},
 		};
-		return this.request<CallDetailsResponse>('POST', '/calls/extensive', body);
+		const response = await this.request('POST', '/calls/extensive', body);
+		return parseCallDetailsResponse(response);
 	}
 
 	/**
@@ -354,16 +146,14 @@ export class GongClient {
 				callIds,
 			},
 		};
-		return this.request<TranscriptsResponse>('POST', '/calls/transcript', body);
+		const response = await this.request('POST', '/calls/transcript', body);
+		return parseTranscriptsResponse(response);
 	}
 
 	/**
 	 * List all users (GET /v2/users)
 	 */
-	async listUsers(options?: {
-		cursor?: string;
-		includeAvatars?: boolean;
-	}): Promise<UsersResponse> {
+	async listUsers(options?: ListUsersRequest): Promise<UsersResponse> {
 		const params: Record<string, string> = {};
 
 		if (options?.cursor) {
@@ -373,47 +163,7 @@ export class GongClient {
 			params.includeAvatars = String(options.includeAvatars);
 		}
 
-		return this.get<UsersResponse>('/users', params);
-	}
-
-	/**
-	 * Search for calls with filters (POST /v2/calls/extensive)
-	 * Use this for advanced filtering by user IDs or call IDs
-	 */
-	async searchCalls(options?: {
-		fromDateTime?: string;
-		toDateTime?: string;
-		workspaceId?: string;
-		primaryUserIds?: string[];
-		callIds?: string[];
-		cursor?: string;
-	}): Promise<CallDetailsResponse> {
-		const body: Record<string, unknown> = {
-			filter: {},
-		};
-
-		if (options?.fromDateTime) {
-			(body.filter as Record<string, unknown>).fromDateTime =
-				options.fromDateTime;
-		}
-		if (options?.toDateTime) {
-			(body.filter as Record<string, unknown>).toDateTime = options.toDateTime;
-		}
-		if (options?.workspaceId) {
-			(body.filter as Record<string, unknown>).workspaceId =
-				options.workspaceId;
-		}
-		if (options?.primaryUserIds?.length) {
-			(body.filter as Record<string, unknown>).primaryUserIds =
-				options.primaryUserIds;
-		}
-		if (options?.callIds?.length) {
-			(body.filter as Record<string, unknown>).callIds = options.callIds;
-		}
-		if (options?.cursor) {
-			body.cursor = options.cursor;
-		}
-
-		return this.request<CallDetailsResponse>('POST', '/calls/extensive', body);
+		const response = await this.get('/users', params);
+		return parseUsersResponse(response);
 	}
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,615 @@
+/**
+ * Zod schemas for Gong API request/response validation
+ * Based on Gong API v2 documentation
+ * https://gong.app.gong.io/settings/api/documentation
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Common Patterns & Primitives
+// ============================================================================
+
+/**
+ * ISO 8601 datetime string validation
+ * Accepts formats like: 2024-01-01T00:00:00Z or 2024-01-01T00:00:00-07:00
+ */
+export const iso8601DateTimeSchema = z
+	.string()
+	.regex(
+		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+		'Must be a valid ISO 8601 datetime (e.g., 2024-01-01T00:00:00Z)',
+	);
+
+/**
+ * Gong ID validation - numeric string up to 20 digits
+ */
+export const gongIdSchema = z
+	.string()
+	.regex(/^\d{1,20}$/, 'Must be a numeric string up to 20 digits');
+
+/**
+ * Pagination cursor - opaque string from API
+ */
+export const cursorSchema = z.string().min(1);
+
+// ============================================================================
+// Request Schemas (for input validation)
+// ============================================================================
+
+/**
+ * GET /v2/calls - List calls request parameters
+ */
+export const listCallsRequestSchema = z
+	.object({
+		fromDateTime: iso8601DateTimeSchema.optional(),
+		toDateTime: iso8601DateTimeSchema.optional(),
+		workspaceId: gongIdSchema.optional(),
+		cursor: cursorSchema.optional(),
+	})
+	.refine(
+		(data) => {
+			// If both dates provided, fromDateTime must be before toDateTime
+			if (data.fromDateTime && data.toDateTime) {
+				return new Date(data.fromDateTime) < new Date(data.toDateTime);
+			}
+			return true;
+		},
+		{
+			message: 'fromDateTime must be before toDateTime',
+		},
+	);
+
+export type ListCallsRequest = z.infer<typeof listCallsRequestSchema>;
+
+/**
+ * POST /v2/calls/extensive - Search calls with filters
+ */
+export const searchCallsRequestSchema = z
+	.object({
+		fromDateTime: iso8601DateTimeSchema.optional(),
+		toDateTime: iso8601DateTimeSchema.optional(),
+		workspaceId: gongIdSchema.optional(),
+		primaryUserIds: z.array(gongIdSchema).optional(),
+		callIds: z.array(gongIdSchema).optional(),
+		cursor: cursorSchema.optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.fromDateTime && data.toDateTime) {
+				return new Date(data.fromDateTime) < new Date(data.toDateTime);
+			}
+			return true;
+		},
+		{
+			message: 'fromDateTime must be before toDateTime',
+		},
+	);
+
+export type SearchCallsRequest = z.infer<typeof searchCallsRequestSchema>;
+
+/**
+ * Get call summary - single call ID
+ */
+export const getCallSummaryRequestSchema = z.object({
+	callId: gongIdSchema,
+});
+
+export type GetCallSummaryRequest = z.infer<typeof getCallSummaryRequestSchema>;
+
+/**
+ * Get call transcript - single call ID
+ */
+export const getCallTranscriptRequestSchema = z.object({
+	callId: gongIdSchema,
+});
+
+export type GetCallTranscriptRequest = z.infer<typeof getCallTranscriptRequestSchema>;
+
+/**
+ * GET /v2/users - List users request parameters
+ */
+export const listUsersRequestSchema = z.object({
+	cursor: cursorSchema.optional(),
+	includeAvatars: z.boolean().optional(),
+});
+
+export type ListUsersRequest = z.infer<typeof listUsersRequestSchema>;
+
+// ============================================================================
+// Response Schemas (for API response parsing)
+// ============================================================================
+
+/**
+ * Pagination records info in responses
+ */
+export const recordsSchema = z.object({
+	cursor: z.string().optional(),
+	totalRecords: z.number(),
+	currentPageSize: z.number(),
+	currentPageNumber: z.number(),
+});
+
+/**
+ * Call scope enum
+ */
+export const callScopeSchema = z.enum(['Internal', 'External', 'Unknown']);
+
+/**
+ * Call direction enum
+ */
+export const callDirectionSchema = z.enum(['Inbound', 'Outbound', 'Conference', 'Unknown']);
+
+/**
+ * Call media type enum
+ */
+export const callMediaSchema = z.enum(['Video', 'Audio']);
+
+/**
+ * Basic call data from GET /v2/calls
+ * Note: Gong API returns null for empty fields, so we use .nullish()
+ */
+export const callSchema = z.object({
+	id: z.string(),
+	title: z.string().nullish(),
+	scheduled: z.string().nullish(),
+	started: z.string().nullish(),
+	duration: z.number().nullish(),
+	primaryUserId: z.string().nullish(),
+	direction: z.string().nullish(),
+	scope: z.string().nullish(),
+	media: z.string().nullish(),
+	language: z.string().nullish(),
+	workspaceId: z.string().nullish(),
+	url: z.string().nullish(),
+});
+
+export type Call = z.infer<typeof callSchema>;
+
+/**
+ * GET /v2/calls response
+ */
+export const callsResponseSchema = z.object({
+	requestId: z.string(),
+	records: recordsSchema,
+	calls: z.array(callSchema),
+});
+
+export type CallsResponse = z.infer<typeof callsResponseSchema>;
+
+/**
+ * Sentence in a transcript
+ */
+export const sentenceSchema = z.object({
+	start: z.number(),
+	end: z.number(),
+	text: z.string(),
+});
+
+/**
+ * Monologue (speaker segment) in a transcript
+ */
+export const transcriptEntrySchema = z.object({
+	speakerId: z.string(),
+	topic: z.string().nullish(),
+	sentences: z.array(sentenceSchema),
+});
+
+export type TranscriptEntry = z.infer<typeof transcriptEntrySchema>;
+
+/**
+ * Call transcript
+ */
+export const callTranscriptSchema = z.object({
+	callId: z.string(),
+	transcript: z.array(transcriptEntrySchema),
+});
+
+export type CallTranscript = z.infer<typeof callTranscriptSchema>;
+
+/**
+ * POST /v2/calls/transcript response
+ */
+export const transcriptsResponseSchema = z.object({
+	requestId: z.string(),
+	records: recordsSchema,
+	callTranscripts: z.array(callTranscriptSchema),
+});
+
+export type TranscriptsResponse = z.infer<typeof transcriptsResponseSchema>;
+
+/**
+ * Spoken language settings
+ */
+export const spokenLanguageSchema = z.object({
+	language: z.string(),
+	primary: z.boolean(),
+});
+
+/**
+ * User settings
+ */
+export const userSettingsSchema = z.object({
+	webConferencesRecorded: z.boolean().nullish(),
+	preventWebConferenceRecording: z.boolean().nullish(),
+	telephonyCallsRecorded: z.boolean().nullish(),
+	emailsRecorded: z.boolean().nullish(),
+	preventEmailRecording: z.boolean().nullish(),
+	nonRecordedMeetingsDefaultPrivacy: z.string().nullish(),
+	gpiSettings: z.unknown().nullish(),
+	emailsImported: z.boolean().nullish(),
+});
+
+/**
+ * User data
+ * Note: Gong API returns null for empty fields
+ */
+export const userSchema = z.object({
+	id: z.string(),
+	emailAddress: z.string().nullish(),
+	created: z.string().nullish(),
+	active: z.boolean().nullish(),
+	emailAliases: z.array(z.string()).nullish(),
+	trustedEmailAddress: z.string().nullish(),
+	firstName: z.string().nullish(),
+	lastName: z.string().nullish(),
+	title: z.string().nullish(),
+	phoneNumber: z.string().nullish(),
+	extension: z.string().nullish(),
+	personalMeetingUrls: z.array(z.string()).nullish(),
+	settings: userSettingsSchema.nullish(),
+	managerId: z.string().nullish(),
+	meetingConsentPageUrl: z.string().nullish(),
+	spokenLanguages: z.array(spokenLanguageSchema).nullish(),
+});
+
+export type User = z.infer<typeof userSchema>;
+
+/**
+ * GET /v2/users response
+ */
+export const usersResponseSchema = z.object({
+	requestId: z.string(),
+	records: recordsSchema,
+	users: z.array(userSchema),
+});
+
+export type UsersResponse = z.infer<typeof usersResponseSchema>;
+
+/**
+ * Party (participant) in a call
+ * Note: Gong API returns null for empty fields
+ */
+export const partySchema = z.object({
+	id: z.string().nullish(),
+	emailAddress: z.string().nullish(),
+	name: z.string().nullish(),
+	title: z.string().nullish(),
+	userId: z.string().nullish(),
+	speakerId: z.string().nullish(),
+	context: z
+		.array(
+			z.object({
+				system: z.string().nullish(),
+				objects: z
+					.array(
+						z.object({
+							objectType: z.string().nullish(),
+							objectId: z.string().nullish(),
+							fields: z
+								.array(z.object({ name: z.string(), value: z.string() }))
+								.nullish(),
+						}),
+					)
+					.nullish(),
+			}),
+		)
+		.nullish(),
+	affiliation: z.string().nullish(),
+	phoneNumber: z.string().nullish(),
+	methods: z.array(z.string()).nullish(),
+});
+
+/**
+ * Tracker occurrence
+ */
+export const trackerOccurrenceSchema = z.object({
+	startTime: z.number(),
+	speakerId: z.string().nullish(),
+});
+
+/**
+ * Tracker in call content
+ */
+export const trackerSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	count: z.number(),
+	type: z.string().nullish(),
+	occurrences: z.array(trackerOccurrenceSchema).nullish(),
+});
+
+/**
+ * Topic in call content
+ */
+export const topicSchema = z.object({
+	name: z.string(),
+	duration: z.number(),
+});
+
+/**
+ * Action item in call
+ */
+export const actionItemSchema = z.object({
+	snippetStartTime: z.number().nullish(),
+	snippetEndTime: z.number().nullish(),
+	speakerIds: z.array(z.string()).nullish(),
+	snippet: z.string().nullish(),
+});
+
+/**
+ * Outline item
+ */
+export const outlineItemSchema = z.object({
+	text: z.string(),
+	startTime: z.number().nullish(),
+});
+
+/**
+ * Outline section
+ */
+export const outlineSectionSchema = z.object({
+	section: z.string(),
+	startTime: z.number().nullish(),
+	duration: z.number().nullish(),
+	items: z.array(outlineItemSchema).nullish(),
+});
+
+/**
+ * Call outcome
+ */
+export const callOutcomeSchema = z.object({
+	id: z.string().nullish(),
+	category: z.string().nullish(),
+	name: z.string().nullish(),
+});
+
+/**
+ * Key point
+ */
+export const keyPointSchema = z.object({
+	text: z.string(),
+});
+
+/**
+ * Call content (detailed data)
+ */
+export const callContentSchema = z.object({
+	trackers: z.array(trackerSchema).nullish(),
+	topics: z.array(topicSchema).nullish(),
+	pointsOfInterest: z
+		.object({
+			actionItems: z.array(actionItemSchema).nullish(),
+		})
+		.nullish(),
+	brief: z.string().nullish(),
+	outline: z.array(outlineSectionSchema).nullish(),
+	callOutcome: callOutcomeSchema.nullish(),
+	keyPoints: z.array(keyPointSchema).nullish(),
+});
+
+/**
+ * Speaker stats
+ */
+export const speakerSchema = z.object({
+	id: z.string(),
+	visibility: z.number().nullish(),
+	talkTime: z.number().nullish(),
+});
+
+/**
+ * Video segment
+ */
+export const videoSegmentSchema = z.object({
+	name: z.string(),
+	duration: z.number(),
+});
+
+/**
+ * Call interaction data
+ */
+export const interactionSchema = z.object({
+	speakers: z.array(speakerSchema).nullish(),
+	interactivity: z.number().nullish(),
+	video: z.array(videoSegmentSchema).nullish(),
+	questions: z
+		.object({
+			companyCount: z.number().nullish(),
+			nonCompanyCount: z.number().nullish(),
+		})
+		.nullish(),
+});
+
+/**
+ * Public comment
+ */
+export const publicCommentSchema = z.object({
+	id: z.string(),
+	audioStartTime: z.number().nullish(),
+	audioEndTime: z.number().nullish(),
+	commenterUserId: z.string().nullish(),
+	comment: z.string().nullish(),
+	posted: z.string().nullish(),
+	inReplyTo: z.string().nullish(),
+	duringCall: z.boolean().nullish(),
+});
+
+/**
+ * Call collaboration data
+ */
+export const collaborationSchema = z.object({
+	publicComments: z.array(publicCommentSchema).nullish(),
+});
+
+/**
+ * Call media URLs
+ */
+export const mediaSchema = z.object({
+	audioUrl: z.string().nullish(),
+	videoUrl: z.string().nullish(),
+});
+
+/**
+ * Call metadata
+ * Note: Gong API returns null for empty fields, so we use .nullish() (allows null | undefined)
+ */
+export const callMetadataSchema = z.object({
+	id: z.string(),
+	url: z.string().nullish(),
+	title: z.string().nullish(),
+	scheduled: z.string().nullish(),
+	started: z.string().nullish(),
+	duration: z.number().nullish(),
+	primaryUserId: z.string().nullish(),
+	direction: z.string().nullish(),
+	system: z.string().nullish(),
+	scope: z.string().nullish(),
+	media: z.string().nullish(),
+	language: z.string().nullish(),
+	workspaceId: z.string().nullish(),
+	sdrDisposition: z.string().nullish(),
+	clientUniqueId: z.string().nullish(),
+	customData: z.string().nullish(),
+	purpose: z.string().nullish(),
+	meetingUrl: z.string().nullish(),
+	isPrivate: z.boolean().nullish(),
+	calendarEventId: z.string().nullish(),
+});
+
+/**
+ * Context object field
+ */
+export const contextFieldSchema = z.object({
+	name: z.string(),
+	value: z.string(),
+});
+
+/**
+ * Context object (CRM, etc)
+ */
+export const contextObjectSchema = z.object({
+	objectType: z.string().nullish(),
+	objectId: z.string().nullish(),
+	fields: z.array(contextFieldSchema).nullish(),
+	timing: z.string().nullish(),
+});
+
+/**
+ * Context (external system links)
+ */
+export const contextSchema = z.object({
+	system: z.string().nullish(),
+	objects: z.array(contextObjectSchema).nullish(),
+});
+
+/**
+ * Detailed call data from POST /v2/calls/extensive
+ */
+export const callDetailsSchema = z.object({
+	metaData: callMetadataSchema,
+	context: z.array(contextSchema).nullish(),
+	parties: z.array(partySchema).nullish(),
+	content: callContentSchema.nullish(),
+	interaction: interactionSchema.nullish(),
+	collaboration: collaborationSchema.nullish(),
+	media: mediaSchema.nullish(),
+});
+
+export type CallDetails = z.infer<typeof callDetailsSchema>;
+
+/**
+ * POST /v2/calls/extensive response
+ */
+export const callDetailsResponseSchema = z.object({
+	requestId: z.string(),
+	records: z.object({
+		totalRecords: z.number(),
+		currentPageSize: z.number(),
+		currentPageNumber: z.number(),
+		cursor: z.string().optional(),
+	}),
+	calls: z.array(callDetailsSchema),
+});
+
+export type CallDetailsResponse = z.infer<typeof callDetailsResponseSchema>;
+
+// ============================================================================
+// Validation Helper Functions
+// ============================================================================
+
+/**
+ * Validate and parse list calls request
+ */
+export function validateListCallsRequest(input: unknown): ListCallsRequest {
+	return listCallsRequestSchema.parse(input ?? {});
+}
+
+/**
+ * Validate and parse search calls request
+ */
+export function validateSearchCallsRequest(input: unknown): SearchCallsRequest {
+	return searchCallsRequestSchema.parse(input ?? {});
+}
+
+/**
+ * Validate and parse get call summary request
+ */
+export function validateGetCallSummaryRequest(
+	input: unknown,
+): GetCallSummaryRequest {
+	return getCallSummaryRequestSchema.parse(input);
+}
+
+/**
+ * Validate and parse get call transcript request
+ */
+export function validateGetCallTranscriptRequest(
+	input: unknown,
+): GetCallTranscriptRequest {
+	return getCallTranscriptRequestSchema.parse(input);
+}
+
+/**
+ * Validate and parse list users request
+ */
+export function validateListUsersRequest(input: unknown): ListUsersRequest {
+	return listUsersRequestSchema.parse(input ?? {});
+}
+
+/**
+ * Parse and validate calls response
+ */
+export function parseCallsResponse(data: unknown): CallsResponse {
+	return callsResponseSchema.parse(data);
+}
+
+/**
+ * Parse and validate call details response
+ */
+export function parseCallDetailsResponse(data: unknown): CallDetailsResponse {
+	return callDetailsResponseSchema.parse(data);
+}
+
+/**
+ * Parse and validate transcripts response
+ */
+export function parseTranscriptsResponse(data: unknown): TranscriptsResponse {
+	return transcriptsResponseSchema.parse(data);
+}
+
+/**
+ * Parse and validate users response
+ */
+export function parseUsersResponse(data: unknown): UsersResponse {
+	return usersResponseSchema.parse(data);
+}

--- a/test/formatters.test.ts
+++ b/test/formatters.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import {
+	formatCallsResponse,
+	formatCallSummary,
+	formatCallTranscript,
+	formatUsersResponse,
+} from '../src/formatters.js';
+import type {
+	CallsResponse,
+	CallDetails,
+	CallTranscript,
+	UsersResponse,
+} from '../src/schemas.js';
+
+describe('formatCallsResponse', () => {
+	it('formats empty calls list', () => {
+		const response: CallsResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 0,
+				currentPageSize: 0,
+				currentPageNumber: 1,
+			},
+			calls: [],
+		};
+
+		const result = formatCallsResponse(response);
+		expect(result).toContain('**Calls** (0 total)');
+		expect(result).toContain('No calls found.');
+	});
+
+	it('formats calls as markdown table', () => {
+		const response: CallsResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 2,
+				currentPageSize: 2,
+				currentPageNumber: 1,
+			},
+			calls: [
+				{
+					id: '123',
+					title: 'Sales Call',
+					started: '2024-01-15T10:00:00Z',
+					duration: 1800,
+					scope: 'External',
+				},
+				{
+					id: '456',
+					title: 'Demo Call',
+					started: '2024-01-16T14:00:00Z',
+					duration: 3600,
+					scope: 'External',
+				},
+			],
+		};
+
+		const result = formatCallsResponse(response);
+		expect(result).toContain('**Calls** (2 total)');
+		expect(result).toContain('| ID | Title | Date | Duration | Scope |');
+		expect(result).toContain('| 123 | Sales Call |');
+		expect(result).toContain('| 456 | Demo Call |');
+		expect(result).toContain('30m'); // 1800 seconds = 30 minutes
+		expect(result).toContain('60m'); // 3600 seconds = 60 minutes
+	});
+
+	it('includes cursor when available', () => {
+		const response: CallsResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 100,
+				currentPageSize: 10,
+				currentPageNumber: 1,
+				cursor: 'next-page-cursor',
+			},
+			calls: [{ id: '123' }],
+		};
+
+		const result = formatCallsResponse(response);
+		expect(result).toContain('`next-page-cursor`');
+	});
+
+	it('escapes pipe characters in titles', () => {
+		const response: CallsResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 1,
+				currentPageSize: 1,
+				currentPageNumber: 1,
+			},
+			calls: [
+				{
+					id: '123',
+					title: 'Call | With | Pipes',
+				},
+			],
+		};
+
+		const result = formatCallsResponse(response);
+		expect(result).toContain('Call \\| With \\| Pipes');
+	});
+});
+
+describe('formatUsersResponse', () => {
+	it('formats empty users list', () => {
+		const response: UsersResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 0,
+				currentPageSize: 0,
+				currentPageNumber: 1,
+			},
+			users: [],
+		};
+
+		const result = formatUsersResponse(response);
+		expect(result).toContain('**Users** (0 total)');
+		expect(result).toContain('No users found.');
+	});
+
+	it('formats users as markdown table', () => {
+		const response: UsersResponse = {
+			requestId: 'test-123',
+			records: {
+				totalRecords: 2,
+				currentPageSize: 2,
+				currentPageNumber: 1,
+			},
+			users: [
+				{
+					id: '111',
+					firstName: 'John',
+					lastName: 'Doe',
+					emailAddress: 'john@example.com',
+					title: 'Sales Rep',
+					active: true,
+				},
+				{
+					id: '222',
+					firstName: 'Jane',
+					lastName: 'Smith',
+					emailAddress: 'jane@example.com',
+					title: 'Account Executive',
+					active: false,
+				},
+			],
+		};
+
+		const result = formatUsersResponse(response);
+		expect(result).toContain('**Users** (2 total)');
+		expect(result).toContain('| ID | Name | Email | Title | Active |');
+		expect(result).toContain('| 111 | John Doe | john@example.com | Sales Rep | Yes |');
+		expect(result).toContain('| 222 | Jane Smith | jane@example.com | Account Executive | No |');
+	});
+});
+
+describe('formatCallSummary', () => {
+	it('formats call summary with basic metadata', () => {
+		const call: CallDetails = {
+			metaData: {
+				id: '123',
+				title: 'Important Sales Call',
+				started: '2024-01-15T10:00:00Z',
+				duration: 1800,
+				scope: 'External',
+				url: 'https://gong.io/call/123',
+			},
+		};
+
+		const result = formatCallSummary(call);
+		expect(result).toContain('## Important Sales Call');
+		expect(result).toContain('**ID:** 123');
+		expect(result).toContain('**Duration:** 30m');
+		expect(result).toContain('**Scope:** External');
+		expect(result).toContain('**URL:** https://gong.io/call/123');
+	});
+
+	it('formats call summary with participants', () => {
+		const call: CallDetails = {
+			metaData: {
+				id: '123',
+				title: 'Team Call',
+			},
+			parties: [
+				{ name: 'John Doe', affiliation: 'Internal' },
+				{ name: 'Jane Customer', affiliation: 'External' },
+			],
+		};
+
+		const result = formatCallSummary(call);
+		expect(result).toContain('### Participants');
+		expect(result).toContain('John Doe (Internal)');
+		expect(result).toContain('Jane Customer (External)');
+	});
+
+	it('formats call summary with brief and key points', () => {
+		const call: CallDetails = {
+			metaData: {
+				id: '123',
+				title: 'Sales Call',
+			},
+			content: {
+				brief: 'Productive discussion about enterprise features.',
+				keyPoints: [
+					{ text: 'Customer interested in enterprise plan' },
+					{ text: 'Follow-up scheduled for next week' },
+				],
+			},
+		};
+
+		const result = formatCallSummary(call);
+		expect(result).toContain('### Summary');
+		expect(result).toContain('Productive discussion about enterprise features.');
+		expect(result).toContain('### Key Points');
+		expect(result).toContain('- Customer interested in enterprise plan');
+		expect(result).toContain('- Follow-up scheduled for next week');
+	});
+
+	it('formats call summary with topics', () => {
+		const call: CallDetails = {
+			metaData: {
+				id: '123',
+				title: 'Demo Call',
+			},
+			content: {
+				topics: [
+					{ name: 'Pricing', duration: 600 },
+					{ name: 'Features', duration: 900 },
+				],
+			},
+		};
+
+		const result = formatCallSummary(call);
+		expect(result).toContain('### Topics');
+		expect(result).toContain('Pricing (10m)');
+		expect(result).toContain('Features (15m)');
+	});
+});
+
+describe('formatCallTranscript', () => {
+	it('formats transcript with speaker names from parties', () => {
+		const transcript: CallTranscript = {
+			callId: '123',
+			transcript: [
+				{
+					speakerId: 'speaker-1',
+					sentences: [
+						{ start: 0, end: 5000, text: 'Hello, welcome to the call.' },
+					],
+				},
+				{
+					speakerId: 'speaker-2',
+					sentences: [
+						{ start: 5000, end: 10000, text: 'Thanks for having me.' },
+					],
+				},
+			],
+		};
+
+		const parties = [
+			{ speakerId: 'speaker-1', name: 'John Host' },
+			{ speakerId: 'speaker-2', name: 'Jane Guest' },
+		];
+
+		const result = formatCallTranscript(transcript, parties);
+		expect(result).toContain('## Transcript (Call 123)');
+		expect(result).toContain('[John Host]: Hello, welcome to the call.');
+		expect(result).toContain('[Jane Guest]: Thanks for having me.');
+	});
+
+	it('uses speaker ID when no party info available', () => {
+		const transcript: CallTranscript = {
+			callId: '456',
+			transcript: [
+				{
+					speakerId: 'unknown-speaker',
+					sentences: [
+						{ start: 0, end: 3000, text: 'Some text here.' },
+					],
+				},
+			],
+		};
+
+		const result = formatCallTranscript(transcript, null);
+		expect(result).toContain('[Speaker unknown-speaker]: Some text here.');
+	});
+
+	it('handles empty transcript', () => {
+		const transcript: CallTranscript = {
+			callId: '789',
+			transcript: [],
+		};
+
+		const result = formatCallTranscript(transcript, null);
+		expect(result).toContain('## Transcript (Call 789)');
+		expect(result).toContain('*No transcript available*');
+	});
+
+	it('joins multiple sentences in a monologue', () => {
+		const transcript: CallTranscript = {
+			callId: '123',
+			transcript: [
+				{
+					speakerId: 'speaker-1',
+					sentences: [
+						{ start: 0, end: 2000, text: 'First sentence.' },
+						{ start: 2000, end: 4000, text: 'Second sentence.' },
+						{ start: 4000, end: 6000, text: 'Third sentence.' },
+					],
+				},
+			],
+		};
+
+		const result = formatCallTranscript(transcript, null);
+		expect(result).toContain('First sentence. Second sentence. Third sentence.');
+	});
+});

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+import {
+	iso8601DateTimeSchema,
+	gongIdSchema,
+	listCallsRequestSchema,
+	searchCallsRequestSchema,
+	getCallSummaryRequestSchema,
+	getCallTranscriptRequestSchema,
+	listUsersRequestSchema,
+	validateListCallsRequest,
+	validateSearchCallsRequest,
+	validateGetCallSummaryRequest,
+	validateGetCallTranscriptRequest,
+	validateListUsersRequest,
+} from '../src/schemas.js';
+
+describe('iso8601DateTimeSchema', () => {
+	it('accepts valid ISO 8601 datetime with Z timezone', () => {
+		const result = iso8601DateTimeSchema.safeParse('2024-01-01T00:00:00Z');
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid ISO 8601 datetime with offset timezone', () => {
+		const result = iso8601DateTimeSchema.safeParse('2024-01-01T00:00:00-07:00');
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid ISO 8601 datetime with positive offset', () => {
+		const result = iso8601DateTimeSchema.safeParse('2024-01-01T00:00:00+05:30');
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid ISO 8601 datetime with milliseconds', () => {
+		const result = iso8601DateTimeSchema.safeParse(
+			'2024-01-01T00:00:00.123Z',
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects date-only format', () => {
+		const result = iso8601DateTimeSchema.safeParse('2024-01-01');
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects datetime without timezone', () => {
+		const result = iso8601DateTimeSchema.safeParse('2024-01-01T00:00:00');
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects invalid format', () => {
+		const result = iso8601DateTimeSchema.safeParse('January 1, 2024');
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('gongIdSchema', () => {
+	it('accepts single digit ID', () => {
+		const result = gongIdSchema.safeParse('1');
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts 20-digit ID (maximum)', () => {
+		const result = gongIdSchema.safeParse('12345678901234567890');
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects 21-digit ID (too long)', () => {
+		const result = gongIdSchema.safeParse('123456789012345678901');
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects non-numeric characters', () => {
+		const result = gongIdSchema.safeParse('abc123');
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects empty string', () => {
+		const result = gongIdSchema.safeParse('');
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects ID with spaces', () => {
+		const result = gongIdSchema.safeParse('123 456');
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('listCallsRequestSchema', () => {
+	it('accepts empty object', () => {
+		const result = listCallsRequestSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid date range', () => {
+		const result = listCallsRequestSchema.safeParse({
+			fromDateTime: '2024-01-01T00:00:00Z',
+			toDateTime: '2024-01-31T23:59:59Z',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects when fromDateTime is after toDateTime', () => {
+		const result = listCallsRequestSchema.safeParse({
+			fromDateTime: '2024-01-31T00:00:00Z',
+			toDateTime: '2024-01-01T00:00:00Z',
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe(
+				'fromDateTime must be before toDateTime',
+			);
+		}
+	});
+
+	it('accepts valid workspaceId', () => {
+		const result = listCallsRequestSchema.safeParse({
+			workspaceId: '12345',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects invalid workspaceId format', () => {
+		const result = listCallsRequestSchema.safeParse({
+			workspaceId: 'not-a-number',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('searchCallsRequestSchema', () => {
+	it('accepts empty object', () => {
+		const result = searchCallsRequestSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid primaryUserIds array', () => {
+		const result = searchCallsRequestSchema.safeParse({
+			primaryUserIds: ['123', '456', '789'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects invalid primaryUserIds format', () => {
+		const result = searchCallsRequestSchema.safeParse({
+			primaryUserIds: ['abc'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts valid callIds array', () => {
+		const result = searchCallsRequestSchema.safeParse({
+			callIds: ['123456789'],
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('getCallSummaryRequestSchema', () => {
+	it('accepts valid callId', () => {
+		const result = getCallSummaryRequestSchema.safeParse({
+			callId: '123456789',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing callId', () => {
+		const result = getCallSummaryRequestSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects invalid callId format', () => {
+		const result = getCallSummaryRequestSchema.safeParse({
+			callId: 'invalid-id',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('getCallTranscriptRequestSchema', () => {
+	it('accepts valid callId', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects missing callId', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects invalid callId format', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: 'not-valid',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('listUsersRequestSchema', () => {
+	it('accepts empty object', () => {
+		const result = listUsersRequestSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts valid cursor', () => {
+		const result = listUsersRequestSchema.safeParse({
+			cursor: 'abc123',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts includeAvatars boolean', () => {
+		const result = listUsersRequestSchema.safeParse({
+			includeAvatars: true,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects empty cursor', () => {
+		const result = listUsersRequestSchema.safeParse({
+			cursor: '',
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('validate helper functions', () => {
+	it('validateListCallsRequest returns validated object', () => {
+		const result = validateListCallsRequest({
+			fromDateTime: '2024-01-01T00:00:00Z',
+		});
+		expect(result.fromDateTime).toBe('2024-01-01T00:00:00Z');
+	});
+
+	it('validateListCallsRequest handles undefined', () => {
+		const result = validateListCallsRequest(undefined);
+		expect(result).toEqual({});
+	});
+
+	it('validateSearchCallsRequest throws on invalid input', () => {
+		expect(() =>
+			validateSearchCallsRequest({
+				fromDateTime: 'invalid-date',
+			}),
+		).toThrow(ZodError);
+	});
+
+	it('validateGetCallSummaryRequest validates callId', () => {
+		const result = validateGetCallSummaryRequest({
+			callId: '123',
+		});
+		expect(result.callId).toBe('123');
+	});
+
+	it('validateGetCallSummaryRequest throws on missing callId', () => {
+		expect(() =>
+			validateGetCallSummaryRequest({}),
+		).toThrow(ZodError);
+	});
+
+	it('validateGetCallTranscriptRequest validates callId', () => {
+		const result = validateGetCallTranscriptRequest({
+			callId: '456',
+		});
+		expect(result.callId).toBe('456');
+	});
+
+	it('validateListUsersRequest handles options', () => {
+		const result = validateListUsersRequest({
+			includeAvatars: true,
+		});
+		expect(result.includeAvatars).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- Add comprehensive Zod schemas for all Gong API request/response types with ISO 8601 datetime validation and Gong ID validation
- Add markdown formatters to reduce token usage in LLM responses (tables instead of JSON)
- Replace batch tools with single-call tools to prevent context window overflow:
  - `list_calls` - returns minimal call metadata in table format
  - `get_call_summary` - returns summary for a single call with key points, topics, and action items
  - `get_call_transcript` - returns transcript with speaker name resolution from parties array
  - `list_users` - returns user list in compact table format
- Use `.nullish()` for all response schema fields to handle `null` values returned by Gong API

## Test plan

- [x] All 54 tests pass (`pnpm test`)
- [x] TypeScript type checking passes (`pnpm run typecheck`)
- [x] MCP validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)