### PR TITLE
feat: request AI-generated summaries and add transcript truncation

### DIFF
--- a/src/gong.ts
+++ b/src/gong.ts
@@ -126,11 +126,33 @@ export class GongClient {
 
 	/**
 	 * Get detailed information about specific calls (POST /v2/calls/extensive)
+	 * Includes AI-generated summaries (brief, keyPoints, outline, topics, actionItems)
 	 */
 	async getCallDetails(callIds: string[]): Promise<CallDetailsResponse> {
 		const body = {
 			filter: {
 				callIds,
+			},
+			contentSelector: {
+				exposedFields: {
+					content: {
+						brief: true,
+						outline: true,
+						keyPoints: true,
+						topics: true,
+						pointsOfInterest: true,
+						callOutcome: true,
+						trackers: true,
+					},
+					parties: true,
+					collaboration: {
+						publicComments: true,
+					},
+					interaction: {
+						speakers: true,
+						questions: true,
+					},
+				},
 			},
 		};
 		const response = await this.request('POST', '/calls/extensive', body);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -98,10 +98,26 @@ export const getCallSummaryRequestSchema = z.object({
 export type GetCallSummaryRequest = z.infer<typeof getCallSummaryRequestSchema>;
 
 /**
- * Get call transcript - single call ID
+ * Get call transcript - single call ID with optional truncation
+ * Default maxLength is 10000 characters (~10KB) to prevent context overflow
  */
 export const getCallTranscriptRequestSchema = z.object({
 	callId: gongIdSchema,
+	maxLength: z
+		.number()
+		.int()
+		.min(1000)
+		.max(100000)
+		.default(10000)
+		.describe(
+			'Maximum characters to return (default: 10000). Use offset to paginate through longer transcripts.',
+		),
+	offset: z
+		.number()
+		.int()
+		.min(0)
+		.default(0)
+		.describe('Character offset to start from (default: 0). Use with maxLength to paginate.'),
 });
 
 export type GetCallTranscriptRequest = z.infer<typeof getCallTranscriptRequestSchema>;

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -196,6 +196,72 @@ describe('getCallTranscriptRequestSchema', () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	it('applies default maxLength of 10000', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.maxLength).toBe(10000);
+		}
+	});
+
+	it('accepts custom maxLength within bounds', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+			maxLength: 50000,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.maxLength).toBe(50000);
+		}
+	});
+
+	it('rejects maxLength below minimum (1000)', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+			maxLength: 500,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects maxLength above maximum (100000)', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+			maxLength: 150000,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('applies default offset of 0', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.offset).toBe(0);
+		}
+	});
+
+	it('accepts custom offset', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+			offset: 5000,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.offset).toBe(5000);
+		}
+	});
+
+	it('rejects negative offset', () => {
+		const result = getCallTranscriptRequestSchema.safeParse({
+			callId: '123456789',
+			offset: -100,
+		});
+		expect(result.success).toBe(false);
+	});
 });
 
 describe('listUsersRequestSchema', () => {


### PR DESCRIPTION
## Summary

- Add `contentSelector` to `getCallDetails()` to request AI-generated content (brief, keyPoints, outline, topics, actionItems)
- Add outline section to `formatCallSummary()` for detailed section-by-section breakdown
- Add transcript truncation with `maxLength` (default 10KB) and `offset` parameters to prevent context overflow
- Update tool descriptions to recommend summaries over raw transcripts

## Context

Analysis showed that raw transcripts can be 20-45KB for typical calls (~1KB per minute). AI-generated summaries provide **60%+ size savings** while offering richer, structured insights:

| Call Duration | Summary Size | Transcript Size | Savings |
|---------------|--------------|-----------------|---------|
| 49m | 14.9KB | 41.6KB | 64% |
| 24m | 8.1KB | 20.9KB | 61% |
| 41m | 12.6KB | 32.4KB | 61% |

## Test plan

- [x] All 64 tests pass (`pnpm test`)
- [x] TypeScript type checking passes (`pnpm run typecheck`)
- [x] MCP validation passes
- [x] Tested against real Gong API - AI summaries now populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)