### PR TITLE
feat: add search_calls_by_account, search_calls_by_opportunity, search_transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 
 # MCP registry token files
 .mcpregistry_*
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ An MCP (Model Context Protocol) server that provides access to your Gong.io data
 | [`get_call_summary`](#get_call_summary) | AI summary: key points, topics, action items |
 | [`get_call_transcript`](#get_call_transcript) | Full speaker-attributed transcript (paginated) |
 | [`search_calls`](#search_calls) | Advanced call search by host, ID, date range |
+| [`search_calls_by_account`](#search_calls_by_account) | Find calls involving a specific account/company by email domain |
+| [`search_calls_by_opportunity`](#search_calls_by_opportunity) | Find calls linked to specific CRM Opportunities |
+| [`search_transcripts`](#search_transcripts) | Free-text keyword search across transcript sentences |
 | [`get_trackers`](#get_trackers) | List keyword trackers (competitors, topics, etc.) |
 | [`list_workspaces`](#list_workspaces) | List workspaces and get IDs for use in other tools |
 | [`list_library_folders`](#list_library_folders) | List public call library folders |
@@ -235,6 +238,90 @@ Search calls with advanced filters. More flexible than `list_calls` for targeted
 
 </details>
 
+<a name="search_calls_by_account"></a>
+<details>
+<summary><code>search_calls_by_account</code> — Find calls by account/company (email domain)</summary>
+
+Find calls involving a specific account or company by matching the email domains of external participants. The Gong API does not natively support filtering by account name (a [known gap](https://visioneers.gong.io/data-in-gong-71)) — this tool fetches calls in the date range and post-filters on `parties[].emailAddress`. Auto-paginates the underlying `/v2/calls/extensive` endpoint up to `maxCalls`.
+
+**Use this when:**
+- A prospect has multiple email domains (`acme.com`, `acme.io`, regional TLDs) and you need them all
+- You need to join external enrichment data (e.g., "all prospects on Klaviyo" from BuiltWith / Clearbit / a vendor-stack graph) — resolve to a domain list upstream and pass it here
+- Domain-based matching is more reliable than CRM Account names that drift across systems
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `domains` | **Yes** | Email domains, e.g. `["acme.com", "acme.io"]`. A call matches if any external participant has an email at one of these domains. |
+| `fromDateTime` | No | Start date in ISO 8601 format |
+| `toDateTime` | No | End date in ISO 8601 format |
+| `workspaceId` | No | Filter by workspace ID |
+| `primaryUserIds` | No | Pre-narrow by call host user IDs (faster, server-side) |
+| `matchCrmAccount` | No | Also match where a CRM Account context object name contains a domain root (e.g. `"acme"` from `"acme.com"`). Requires CRM integration. Default `false`. |
+| `maxCalls` | No | Max calls to fetch & filter (default: 500, max: 5000). Auto-paginates underlying API. |
+| `cursor` | No | Pagination cursor (advanced) |
+
+**Cost note:** This is fetch-then-filter. A 90-day window with no other narrowing typically pages through 1–5 API calls. Combine with `primaryUserIds` to bound cost on long ranges.
+
+</details>
+
+<a name="search_calls_by_opportunity"></a>
+<details>
+<summary><code>search_calls_by_opportunity</code> — Find calls linked to a CRM Opportunity</summary>
+
+Find calls linked to specific CRM Opportunities by ID or name substring. Requires Gong-CRM integration (Salesforce / HubSpot) — calls without CRM linkage will not match.
+
+**Use this when:**
+- You want every call on a specific deal — `opportunityIds: ["006xxxxx"]` is the most precise option
+- Opportunity names are descriptive (e.g. `"Acme Q4 Renewal"`) and you want fuzzy matching across renamed/duplicated opportunities
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `opportunityIds` | At least one of `opportunityIds` or `opportunityNames` is required | CRM Opportunity IDs (e.g., Salesforce 18-character IDs) |
+| `opportunityNames` | At least one of `opportunityIds` or `opportunityNames` is required | Name substrings (case-insensitive) matched against the Name field of Opportunity context objects |
+| `fromDateTime` | No | Start date in ISO 8601 format |
+| `toDateTime` | No | End date in ISO 8601 format |
+| `workspaceId` | No | Filter by workspace ID |
+| `primaryUserIds` | No | Pre-narrow by call host user IDs |
+| `maxCalls` | No | Max calls to fetch & filter (default: 500, max: 5000) |
+| `cursor` | No | Pagination cursor (advanced) |
+
+**Cost note:** Uses the same fetch-then-filter pattern as `search_calls_by_account`. CRM context lookup adds no extra API calls — it rides on the same `/v2/calls/extensive` request with `context: "Extended"`.
+
+</details>
+
+<a name="search_transcripts"></a>
+<details>
+<summary><code>search_transcripts</code> — Free-text keyword search across transcripts</summary>
+
+Free-text keyword search across call transcript sentences within a bounded date range. Two-phase: (1) `/v2/calls/extensive` narrows the call set by date + optional `primaryUserIds` / `domains`, (2) `/v2/calls/transcript` fetches transcripts for the narrowed set and returns sentence-level matches with speaker attribution and timestamps.
+
+**Prefer Gong Trackers for recurring terms.** For competitor names, ESP/tech terms (Klaviyo, Braze, Iterable, Postscript, Attentive, Sendgrid, Customer.io, etc.), and other terms you'll search for repeatedly — set them up as Gong Trackers in the UI (one-time, ~30 minutes for ~20 terms). Then use `get_trackers` + `search_calls` + `get_call_summary` instead. Trackers are server-side, the cost is dramatically lower, and they surface counts and timestamps natively. Use `search_transcripts` for ad-hoc one-offs.
+
+**Cost guard:** Date ranges greater than 30 days require additional narrowing via `primaryUserIds` or `domains`. A 6-month unbounded scan would burn API quota and is rejected at the schema level.
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `keywords` | **Yes** | Keywords to search for. Each must be at least 2 characters. |
+| `fromDateTime` | **Yes** | Start of date window (ISO 8601). |
+| `toDateTime` | **Yes** | End of date window (ISO 8601). |
+| `primaryUserIds` | Required if window > 30 days and `domains` not set | Narrow to calls hosted by these users before scanning |
+| `domains` | Required if window > 30 days and `primaryUserIds` not set | Narrow to calls with external parties from these domains before scanning |
+| `workspaceId` | No | Filter by workspace ID |
+| `caseSensitive` | No | Default `false`. |
+| `wholeWord` | No | Default `true` — `"ai"` will not match `"said"` or `"again"`. Set `false` for substring matching. |
+| `maxCalls` | No | Max calls to scan (default: 500). |
+| `maxMatchesPerCall` | No | Max sentence matches returned per call (default: 10) — prevents context overflow on calls with many hits. |
+
+**Returns:** Sentence-level matches grouped by call, including speaker name and affiliation (when available), keyword matched, timestamp (mm:ss), and the sentence snippet.
+
+</details>
+
 <a name="get_trackers"></a>
 <details>
 <summary><code>get_trackers</code> — List keyword trackers</summary>
@@ -360,6 +447,9 @@ Once connected to Claude, you can ask:
 - "Who are all the users in our Gong workspace?"
 - "Search for calls hosted by Justin (user ID 232255198215877499) in July 2025"
 - "Look up these user IDs: 111, 222, 333"
+- "Show me all calls from the past 60 days with anyone at acme.com or acme.io"
+- "Find every call attached to opportunity 006xxxxx"
+- "Find Q3 calls where prospects mentioned Klaviyo or Braze, narrowed to John's calls"
 
 ## Contributing
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -10,6 +10,7 @@ import type {
 	CallTranscript,
 	LibraryFolderCallsResponse,
 	LibraryFoldersResponse,
+	SearchTranscriptsResult,
 	SingleCallResponse,
 	SingleUserResponse,
 	TrackersSettingsResponse,
@@ -522,4 +523,112 @@ export function formatLibraryFolderCallsResponse(
 	}
 
 	return lines.join('\n');
+}
+
+/**
+ * Format a CallDetails list (with parties and CRM context) for the
+ * search_calls_by_account / search_calls_by_opportunity tools.
+ *
+ * Shows each match with the matching parties highlighted so the agent can
+ * see why the call matched without re-fetching.
+ */
+export function formatMatchedCalls(
+	calls: CallDetails[],
+	meta: {
+		header: string;
+		totalScanned: number;
+		matched: number;
+		limitedByMaxCalls: boolean;
+	},
+): string {
+	const lines: string[] = [];
+	lines.push(`**${meta.header}**\n`);
+	lines.push(
+		`Scanned ${meta.totalScanned} call${meta.totalScanned === 1 ? '' : 's'}, matched ${meta.matched}.${meta.limitedByMaxCalls ? ' *(maxCalls limit reached — increase maxCalls or narrow date range to scan more.)*' : ''}\n`,
+	);
+
+	if (calls.length === 0) {
+		lines.push('No matching calls.');
+		return lines.join('\n');
+	}
+
+	lines.push('| ID | Title | Date | Duration | External Parties |');
+	lines.push('|---|---|---|---|---|');
+
+	for (const call of calls) {
+		const m = call.metaData;
+		const date = m.started ? new Date(m.started).toLocaleDateString() : '-';
+		const duration = m.duration ? `${Math.round(m.duration / 60)}m` : '-';
+		const title = escapeMarkdown(m.title?.slice(0, 50) ?? '-');
+		const externals =
+			call.parties
+				?.filter((p) => (p.affiliation ?? '').toLowerCase() === 'external')
+				.map((p) => p.name ?? p.emailAddress ?? '?')
+				.slice(0, 3)
+				.map((s) => escapeMarkdown(s.slice(0, 30)))
+				.join(', ') || '-';
+		lines.push(
+			`| ${m.id} | ${title} | ${date} | ${duration} | ${externals} |`,
+		);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Format keyword match results from search_transcripts.
+ */
+export function formatTranscriptMatches(
+	result: SearchTranscriptsResult,
+): string {
+	const lines: string[] = [];
+	const keywords = result.keywords.map((k) => `\`${k}\``).join(', ');
+	lines.push(`**Transcript matches for ${keywords}**\n`);
+	lines.push(
+		`Scanned ${result.callsScanned} call${result.callsScanned === 1 ? '' : 's'} \u2192 ${result.callsWithMatches} with matches \u2192 ${result.totalMatches} total sentence match${result.totalMatches === 1 ? '' : 'es'}.${result.limitedByMaxCalls ? ' *(maxCalls limit reached.)*' : ''}\n`,
+	);
+
+	if (result.results.length === 0) {
+		lines.push('No matching sentences found.');
+		return lines.join('\n');
+	}
+
+	for (const call of result.results) {
+		const date = call.callStarted
+			? new Date(call.callStarted).toLocaleDateString()
+			: '';
+		const titleLine = call.callTitle
+			? escapeMarkdown(call.callTitle)
+			: `Call ${call.callId}`;
+		lines.push(
+			`\n### ${titleLine}${date ? ` \u2014 ${date}` : ''}` +
+				`${call.truncated ? ' *(matches truncated)*' : ''}`,
+		);
+		lines.push(
+			`*ID:* \`${call.callId}\`${call.callUrl ? ` \u2014 [open in Gong](${call.callUrl})` : ''}`,
+		);
+		lines.push('');
+
+		for (const m of call.matches) {
+			const ts = formatTimestamp(m.startTime);
+			const speaker = m.speakerName
+				? `${escapeMarkdown(m.speakerName)}${m.speakerAffiliation ? ` (${m.speakerAffiliation})` : ''}`
+				: `Speaker ${m.speakerId}`;
+			lines.push(
+				`- \`${ts}\` **${speaker}** \u2014 _${escapeMarkdown(`"${m.snippet}"`)}_ *(matched: ${m.keyword})*`,
+			);
+		}
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Convert milliseconds (Gong's transcript times) to mm:ss.
+ */
+function formatTimestamp(ms: number): string {
+	const totalSec = Math.floor(ms / 1000);
+	const m = Math.floor(totalSec / 60);
+	const s = totalSec % 60;
+	return `${m}:${String(s).padStart(2, '0')}`;
 }

--- a/src/gong.ts
+++ b/src/gong.ts
@@ -466,8 +466,9 @@ export class GongClient {
 			.filter((r): r is string => Boolean(r));
 
 		const matched = fetched.calls.filter((call) => {
-			// Match 1: any party emailAddress ends with @<domain>
+			// Match 1: any external party emailAddress ends with @<domain>
 			const partyMatch = call.parties?.some((p) => {
+				if ((p.affiliation ?? '').toLowerCase() !== 'external') return false;
 				const email = p.emailAddress?.toLowerCase();
 				if (!email) return false;
 				return lowerDomains.some((d) => email.endsWith(`@${d}`));
@@ -484,7 +485,10 @@ export class GongClient {
 						const nameField = obj.fields?.find(
 							(f) => f.name?.toLowerCase() === 'name',
 						);
-						const name = nameField?.value?.toLowerCase();
+						const name =
+							typeof nameField?.value === 'string'
+								? nameField.value.toLowerCase()
+								: undefined;
 						if (!name) continue;
 						if (lowerDomainRoots.some((root) => name.includes(root))) {
 							return true;
@@ -540,7 +544,10 @@ export class GongClient {
 						const nameField = obj.fields?.find(
 							(f) => f.name?.toLowerCase() === 'name',
 						);
-						const name = nameField?.value?.toLowerCase();
+						const name =
+							typeof nameField?.value === 'string'
+								? nameField.value.toLowerCase()
+								: undefined;
 						if (
 							name &&
 							lowerNames.some((needle) => name.includes(needle))
@@ -584,6 +591,7 @@ export class GongClient {
 			const lowerDomains = options.domains.map((d) => d.toLowerCase());
 			candidateCalls = candidateCalls.filter((call) =>
 				call.parties?.some((p) => {
+					if ((p.affiliation ?? '').toLowerCase() !== 'external') return false;
 					const email = p.emailAddress?.toLowerCase();
 					if (!email) return false;
 					return lowerDomains.some((d) => email.endsWith(`@${d}`));

--- a/src/gong.ts
+++ b/src/gong.ts
@@ -6,6 +6,7 @@
 import {
 	type CallDetailsResponse,
 	type CallsResponse,
+	type CallTranscriptMatches,
 	type GetLibraryFolderCallsRequest,
 	type GetTrackersRequest,
 	type LibraryFolderCallsResponse,
@@ -23,10 +24,15 @@ import {
 	parseTranscriptsResponse,
 	parseUsersResponse,
 	parseWorkspacesResponse,
+	type SearchCallsByAccountRequest,
+	type SearchCallsByOpportunityRequest,
+	type SearchTranscriptsRequest,
+	type SearchTranscriptsResult,
 	type SearchUsersRequest,
 	type SingleCallResponse,
 	type SingleUserResponse,
 	type TrackersSettingsResponse,
+	type TranscriptMatch,
 	type TranscriptsResponse,
 	type UsersResponse,
 	type WorkspacesResponse,
@@ -345,5 +351,348 @@ export class GongClient {
 			folderId: options.folderId,
 		});
 		return parseLibraryFolderCallsResponse(response);
+	}
+
+	// ========================================================================
+	// Account / Opportunity / Keyword Search
+	// ========================================================================
+	//
+	// These methods wrap POST /v2/calls/extensive with a richer contentSelector
+	// (parties + Extended context) and post-filter the response, because the
+	// Gong API does not expose server-side filters for account/company,
+	// opportunity, or transcript keywords.
+
+	/**
+	 * Auto-paginating /v2/calls/extensive fetch with parties + Extended context.
+	 * Stops at maxCalls or when the API returns no cursor.
+	 */
+	private async fetchCallsExtensiveWithContext(options: {
+		fromDateTime?: string;
+		toDateTime?: string;
+		workspaceId?: string;
+		primaryUserIds?: string[];
+		callIds?: string[];
+		maxCalls?: number;
+		cursor?: string;
+	}): Promise<{
+		calls: CallDetailsResponse['calls'];
+		totalRecords: number;
+		nextCursor?: string;
+		limitedByMaxCalls: boolean;
+	}> {
+		const filter: Record<string, unknown> = {};
+		if (options.fromDateTime) filter.fromDateTime = options.fromDateTime;
+		if (options.toDateTime) filter.toDateTime = options.toDateTime;
+		if (options.workspaceId) filter.workspaceId = options.workspaceId;
+		if (options.primaryUserIds?.length) {
+			filter.primaryUserIds = options.primaryUserIds;
+		}
+		if (options.callIds?.length) filter.callIds = options.callIds;
+
+		const contentSelector = {
+			context: 'Extended',
+			contextTiming: ['Now'],
+			exposedFields: {
+				parties: true,
+			},
+		};
+
+		const cap = options.maxCalls ?? 500;
+		const accumulated: CallDetailsResponse['calls'] = [];
+		let cursor: string | undefined = options.cursor;
+		let totalRecords = 0;
+		let limitedByMaxCalls = false;
+
+		// Hard ceiling on paginated requests per call (defense against runaway loops).
+		// 50 pages × ~100 records/page = 5000 calls, matches maxCallsSchema ceiling.
+		const MAX_PAGES = 50;
+		for (let page = 0; page < MAX_PAGES; page++) {
+			const body: Record<string, unknown> = { filter, contentSelector };
+			if (cursor) body.cursor = cursor;
+
+			const response = await this.request<unknown>(
+				'POST',
+				'/calls/extensive',
+				body,
+			);
+			const parsed = parseCallDetailsResponse(response);
+			totalRecords = parsed.records.totalRecords;
+
+			for (const call of parsed.calls) {
+				if (accumulated.length >= cap) {
+					limitedByMaxCalls = true;
+					break;
+				}
+				accumulated.push(call);
+			}
+			if (limitedByMaxCalls) break;
+
+			cursor = parsed.records.cursor;
+			if (!cursor) break;
+		}
+
+		return {
+			calls: accumulated,
+			totalRecords,
+			nextCursor: cursor,
+			limitedByMaxCalls,
+		};
+	}
+
+	/**
+	 * Search calls by account/company via email-domain match on parties.
+	 * Optionally also matches on CRM Account context object names.
+	 */
+	async searchCallsByAccount(
+		options: SearchCallsByAccountRequest,
+	): Promise<{
+		calls: CallDetailsResponse['calls'];
+		totalScanned: number;
+		matched: number;
+		limitedByMaxCalls: boolean;
+	}> {
+		const fetched = await this.fetchCallsExtensiveWithContext({
+			fromDateTime: options.fromDateTime,
+			toDateTime: options.toDateTime,
+			workspaceId: options.workspaceId,
+			primaryUserIds: options.primaryUserIds,
+			maxCalls: options.maxCalls,
+			cursor: options.cursor,
+		});
+
+		const lowerDomains = options.domains.map((d) => d.toLowerCase());
+		const lowerDomainRoots = lowerDomains
+			.map((d) => d.split('.')[0])
+			.filter((r): r is string => Boolean(r));
+
+		const matched = fetched.calls.filter((call) => {
+			// Match 1: any party emailAddress ends with @<domain>
+			const partyMatch = call.parties?.some((p) => {
+				const email = p.emailAddress?.toLowerCase();
+				if (!email) return false;
+				return lowerDomains.some((d) => email.endsWith(`@${d}`));
+			});
+			if (partyMatch) return true;
+
+			// Match 2 (opt-in): any CRM Account context object whose name
+			// contains the domain root (e.g. "acme" from "acme.com").
+			if (options.matchCrmAccount && call.context) {
+				for (const ctx of call.context) {
+					if (!ctx.objects) continue;
+					for (const obj of ctx.objects) {
+						if (obj.objectType !== 'Account') continue;
+						const nameField = obj.fields?.find(
+							(f) => f.name?.toLowerCase() === 'name',
+						);
+						const name = nameField?.value?.toLowerCase();
+						if (!name) continue;
+						if (lowerDomainRoots.some((root) => name.includes(root))) {
+							return true;
+						}
+					}
+				}
+			}
+			return false;
+		});
+
+		return {
+			calls: matched,
+			totalScanned: fetched.calls.length,
+			matched: matched.length,
+			limitedByMaxCalls: fetched.limitedByMaxCalls,
+		};
+	}
+
+	/**
+	 * Search calls linked to specific CRM Opportunities.
+	 * Requires Gong-CRM integration; calls without CRM linkage will not match.
+	 */
+	async searchCallsByOpportunity(
+		options: SearchCallsByOpportunityRequest,
+	): Promise<{
+		calls: CallDetailsResponse['calls'];
+		totalScanned: number;
+		matched: number;
+		limitedByMaxCalls: boolean;
+	}> {
+		const fetched = await this.fetchCallsExtensiveWithContext({
+			fromDateTime: options.fromDateTime,
+			toDateTime: options.toDateTime,
+			workspaceId: options.workspaceId,
+			primaryUserIds: options.primaryUserIds,
+			maxCalls: options.maxCalls,
+			cursor: options.cursor,
+		});
+
+		const idSet = new Set(options.opportunityIds ?? []);
+		const lowerNames = (options.opportunityNames ?? []).map((n) =>
+			n.toLowerCase(),
+		);
+
+		const matched = fetched.calls.filter((call) => {
+			if (!call.context) return false;
+			for (const ctx of call.context) {
+				if (!ctx.objects) continue;
+				for (const obj of ctx.objects) {
+					if (obj.objectType !== 'Opportunity') continue;
+					if (obj.objectId && idSet.has(obj.objectId)) return true;
+					if (lowerNames.length > 0) {
+						const nameField = obj.fields?.find(
+							(f) => f.name?.toLowerCase() === 'name',
+						);
+						const name = nameField?.value?.toLowerCase();
+						if (
+							name &&
+							lowerNames.some((needle) => name.includes(needle))
+						) {
+							return true;
+						}
+					}
+				}
+			}
+			return false;
+		});
+
+		return {
+			calls: matched,
+			totalScanned: fetched.calls.length,
+			matched: matched.length,
+			limitedByMaxCalls: fetched.limitedByMaxCalls,
+		};
+	}
+
+	/**
+	 * Free-text keyword search across transcripts within a bounded date range.
+	 * Two phases: (1) narrow call set with extensive, (2) fetch transcripts and
+	 * post-filter sentences. Use Gong Trackers for known recurring terms instead.
+	 */
+	async searchTranscripts(
+		options: SearchTranscriptsRequest,
+	): Promise<SearchTranscriptsResult> {
+		// Phase 1: narrow call set
+		const fetched = await this.fetchCallsExtensiveWithContext({
+			fromDateTime: options.fromDateTime,
+			toDateTime: options.toDateTime,
+			workspaceId: options.workspaceId,
+			primaryUserIds: options.primaryUserIds,
+			maxCalls: options.maxCalls,
+		});
+
+		// Apply domain filter if present
+		let candidateCalls = fetched.calls;
+		if (options.domains && options.domains.length > 0) {
+			const lowerDomains = options.domains.map((d) => d.toLowerCase());
+			candidateCalls = candidateCalls.filter((call) =>
+				call.parties?.some((p) => {
+					const email = p.emailAddress?.toLowerCase();
+					if (!email) return false;
+					return lowerDomains.some((d) => email.endsWith(`@${d}`));
+				}),
+			);
+		}
+
+		if (candidateCalls.length === 0) {
+			return {
+				keywords: options.keywords,
+				callsScanned: 0,
+				callsWithMatches: 0,
+				totalMatches: 0,
+				results: [],
+				limitedByMaxCalls: fetched.limitedByMaxCalls,
+			};
+		}
+
+		// Phase 2: fetch transcripts in batches
+		const callIdToCall = new Map(candidateCalls.map((c) => [c.metaData.id, c]));
+		const callIds = Array.from(callIdToCall.keys());
+
+		// /v2/calls/transcript accepts arrays; Gong recommends modest batch sizes.
+		const TRANSCRIPT_BATCH = 100;
+		const transcripts: TranscriptsResponse['callTranscripts'] = [];
+		for (let i = 0; i < callIds.length; i += TRANSCRIPT_BATCH) {
+			const batch = callIds.slice(i, i + TRANSCRIPT_BATCH);
+			const result = await this.getTranscripts(batch);
+			transcripts.push(...result.callTranscripts);
+		}
+
+		// Build keyword matchers
+		const matchers = options.keywords.map((kw) => {
+			const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const flags = options.caseSensitive ? 'g' : 'gi';
+			const pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
+			return { keyword: kw, regex: new RegExp(pattern, flags) };
+		});
+
+		const results: CallTranscriptMatches[] = [];
+		let totalMatches = 0;
+		const maxPerCall = options.maxMatchesPerCall ?? 10;
+
+		for (const transcript of transcripts) {
+			const call = callIdToCall.get(transcript.callId);
+			if (!call) continue;
+
+			// Build speaker resolution map from parties
+			const speakerInfo = new Map<
+				string,
+				{ name?: string; affiliation?: string }
+			>();
+			for (const p of call.parties ?? []) {
+				if (p.speakerId) {
+					speakerInfo.set(p.speakerId, {
+						name: p.name ?? p.emailAddress ?? undefined,
+						affiliation: p.affiliation ?? undefined,
+					});
+				}
+			}
+
+			const callMatches: TranscriptMatch[] = [];
+			let truncated = false;
+
+			outer: for (const entry of transcript.transcript) {
+				for (const sentence of entry.sentences) {
+					for (const { keyword, regex } of matchers) {
+						regex.lastIndex = 0; // reset because we use /g
+						if (regex.test(sentence.text)) {
+							const info = speakerInfo.get(entry.speakerId);
+							callMatches.push({
+								keyword,
+								speakerId: entry.speakerId,
+								speakerName: info?.name,
+								speakerAffiliation: info?.affiliation,
+								startTime: sentence.start,
+								snippet: sentence.text,
+							});
+							if (callMatches.length >= maxPerCall) {
+								truncated = true;
+								break outer;
+							}
+							break; // one keyword match per sentence is enough
+						}
+					}
+				}
+			}
+
+			if (callMatches.length > 0) {
+				totalMatches += callMatches.length;
+				results.push({
+					callId: transcript.callId,
+					callTitle: call.metaData.title ?? undefined,
+					callStarted: call.metaData.started ?? undefined,
+					callUrl: call.metaData.url ?? undefined,
+					totalMatches: callMatches.length,
+					matches: callMatches,
+					truncated,
+				});
+			}
+		}
+
+		return {
+			keywords: options.keywords,
+			callsScanned: candidateCalls.length,
+			callsWithMatches: results.length,
+			totalMatches,
+			results,
+			limitedByMaxCalls: fetched.limitedByMaxCalls,
+		};
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ import {
 	formatCallTranscript,
 	formatLibraryFolderCallsResponse,
 	formatLibraryFoldersResponse,
+	formatMatchedCalls,
 	formatSingleCall,
 	formatSingleUser,
 	formatTrackersResponse,
+	formatTranscriptMatches,
 	formatUsersResponse,
 	formatWorkspacesResponse,
 } from './formatters.js';
@@ -32,7 +34,10 @@ import {
 	listCallsRequestSchema,
 	listLibraryFoldersRequestSchema,
 	listUsersRequestSchema,
+	searchCallsByAccountRequestSchema,
+	searchCallsByOpportunityRequestSchema,
 	searchCallsRequestSchema,
+	searchTranscriptsRequestSchema,
 	searchUsersRequestSchema,
 } from './schemas.js';
 
@@ -225,6 +230,183 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 							minLength: 1,
 						},
 					},
+				},
+			},
+			{
+				name: 'search_calls_by_account',
+				description:
+					'Find calls involving a specific account/company by matching email domains of external participants. The Gong API does not natively support filtering by account name — this tool fetches calls in the date range and post-filters on parties[].emailAddress. Auto-paginates up to maxCalls. For external tech-stack joins (e.g., "all calls with prospects on Klaviyo"), resolve domains upstream and pass them here.',
+				inputSchema: {
+					type: 'object',
+					properties: {
+						domains: {
+							type: 'array',
+							description:
+								'Email domains (e.g., ["acme.com", "acme.io"]). A call matches if any external participant has an email at one of these domains.',
+							items: { type: 'string' },
+							minItems: 1,
+						},
+						fromDateTime: {
+							type: 'string',
+							description: 'Start date/time in ISO 8601 format.',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+						},
+						toDateTime: {
+							type: 'string',
+							description: 'End date/time in ISO 8601 format.',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+						},
+						workspaceId: {
+							type: 'string',
+							pattern: '^\\d{1,20}$',
+							description: 'Filter by workspace ID.',
+						},
+						primaryUserIds: {
+							type: 'array',
+							description:
+								'Pre-narrow by call host user IDs (faster, server-side).',
+							items: { type: 'string', pattern: '^\\d{1,20}$' },
+						},
+						matchCrmAccount: {
+							type: 'boolean',
+							description:
+								'Also match calls where a CRM Account context object name contains a domain root (e.g., "acme" from "acme.com"). Requires CRM integration. Default false.',
+						},
+						maxCalls: {
+							type: 'number',
+							minimum: 1,
+							maximum: 5000,
+							description:
+								'Maximum calls to fetch and filter (default: 500). Auto-paginates underlying API.',
+						},
+						cursor: {
+							type: 'string',
+							description: 'Pagination cursor (advanced).',
+							minLength: 1,
+						},
+					},
+					required: ['domains'],
+				},
+			},
+			{
+				name: 'search_calls_by_opportunity',
+				description:
+					'Find calls linked to specific CRM Opportunities by ID or name substring. Requires Gong-CRM integration (Salesforce/HubSpot) — calls without CRM linkage will not match. Provide opportunityIds OR opportunityNames (or both).',
+				inputSchema: {
+					type: 'object',
+					properties: {
+						opportunityIds: {
+							type: 'array',
+							description:
+								'CRM Opportunity IDs (e.g., Salesforce 18-character IDs).',
+							items: { type: 'string', minLength: 1 },
+						},
+						opportunityNames: {
+							type: 'array',
+							description:
+								'Opportunity name substrings (case-insensitive). Matches if the Opportunity Name field contains any of these.',
+							items: { type: 'string', minLength: 1 },
+						},
+						fromDateTime: {
+							type: 'string',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+							description: 'Start date/time in ISO 8601 format.',
+						},
+						toDateTime: {
+							type: 'string',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+							description: 'End date/time in ISO 8601 format.',
+						},
+						workspaceId: {
+							type: 'string',
+							pattern: '^\\d{1,20}$',
+							description: 'Filter by workspace ID.',
+						},
+						primaryUserIds: {
+							type: 'array',
+							description: 'Pre-narrow by call host user IDs.',
+							items: { type: 'string', pattern: '^\\d{1,20}$' },
+						},
+						maxCalls: {
+							type: 'number',
+							minimum: 1,
+							maximum: 5000,
+							description: 'Max calls to fetch and filter (default: 500).',
+						},
+						cursor: { type: 'string', minLength: 1 },
+					},
+				},
+			},
+			{
+				name: 'search_transcripts',
+				description:
+					'Free-text keyword search across call transcripts within a bounded date range. Use for ad-hoc searches like "calls mentioning competitor X". For recurring terms, prefer setting up Gong Trackers in the UI and using search_calls + get_call_summary — Trackers are server-side and dramatically cheaper. Date ranges > 30 days require additional narrowing via primaryUserIds or domains. Returns sentence-level matches with speaker attribution and timestamps.',
+				inputSchema: {
+					type: 'object',
+					properties: {
+						keywords: {
+							type: 'array',
+							description:
+								'Keywords to search for. Whole-word, case-insensitive by default.',
+							items: { type: 'string', minLength: 2 },
+							minItems: 1,
+						},
+						fromDateTime: {
+							type: 'string',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+							description: 'REQUIRED. Start of date window (ISO 8601).',
+						},
+						toDateTime: {
+							type: 'string',
+							pattern:
+								'^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$',
+							description: 'REQUIRED. End of date window (ISO 8601).',
+						},
+						primaryUserIds: {
+							type: 'array',
+							description:
+								'Narrow to calls hosted by these users before scanning.',
+							items: { type: 'string', pattern: '^\\d{1,20}$' },
+						},
+						domains: {
+							type: 'array',
+							description:
+								'Narrow to calls with external parties from these email domains before scanning.',
+							items: { type: 'string' },
+						},
+						workspaceId: {
+							type: 'string',
+							pattern: '^\\d{1,20}$',
+						},
+						caseSensitive: {
+							type: 'boolean',
+							description: 'Match keywords case-sensitively. Default false.',
+						},
+						wholeWord: {
+							type: 'boolean',
+							description:
+								'Match whole words only. Default true (recommended).',
+						},
+						maxCalls: {
+							type: 'number',
+							minimum: 1,
+							maximum: 5000,
+							description: 'Max calls to scan (default: 500).',
+						},
+						maxMatchesPerCall: {
+							type: 'number',
+							minimum: 1,
+							maximum: 50,
+							description:
+								'Max sentence matches returned per call (default: 10).',
+						},
+					},
+					required: ['keywords', 'fromDateTime', 'toDateTime'],
 				},
 			},
 			{
@@ -446,6 +628,62 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 							type: 'text',
 							text: formatCallDetailsResponse(result),
 						},
+					],
+				};
+			}
+
+			case 'search_calls_by_account': {
+				const validated = searchCallsByAccountRequestSchema.parse(args);
+				const result = await gong.searchCallsByAccount(validated);
+				return {
+					content: [
+						{
+							type: 'text',
+							text: formatMatchedCalls(result.calls, {
+								header: `Calls for domain${validated.domains.length === 1 ? '' : 's'}: ${validated.domains.join(', ')}`,
+								totalScanned: result.totalScanned,
+								matched: result.matched,
+								limitedByMaxCalls: result.limitedByMaxCalls,
+							}),
+						},
+					],
+				};
+			}
+
+			case 'search_calls_by_opportunity': {
+				const validated =
+					searchCallsByOpportunityRequestSchema.parse(args);
+				const result = await gong.searchCallsByOpportunity(validated);
+				const labels: string[] = [];
+				if (validated.opportunityIds?.length) {
+					labels.push(`IDs: ${validated.opportunityIds.join(', ')}`);
+				}
+				if (validated.opportunityNames?.length) {
+					labels.push(
+						`names: ${validated.opportunityNames.join(', ')}`,
+					);
+				}
+				return {
+					content: [
+						{
+							type: 'text',
+							text: formatMatchedCalls(result.calls, {
+								header: `Calls for opportunity (${labels.join(' / ')})`,
+								totalScanned: result.totalScanned,
+								matched: result.matched,
+								limitedByMaxCalls: result.limitedByMaxCalls,
+							}),
+						},
+					],
+				};
+			}
+
+			case 'search_transcripts': {
+				const validated = searchTranscriptsRequestSchema.parse(args);
+				const result = await gong.searchTranscripts(validated);
+				return {
+					content: [
+						{ type: 'text', text: formatTranscriptMatches(result) },
 					],
 				};
 			}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -831,3 +831,262 @@ export function parseLibraryFolderCallsResponse(
 ): LibraryFolderCallsResponse {
 	return libraryFolderCallsResponseSchema.parse(data);
 }
+
+// ============================================================================
+// Account / Opportunity / Keyword Search Schemas
+// ============================================================================
+//
+// These tools wrap POST /v2/calls/extensive and post-filter the response
+// because the Gong API does not natively support filtering by account/company,
+// opportunity, or transcript keywords. See:
+//   https://visioneers.gong.io/data-in-gong-71  (Account name filter — known gap)
+//   https://visioneers.gong.io/developers-79     (Slide/keyword filter — known gap)
+//
+// Cost note: These are fetch-then-filter. The maxCalls cap bounds API usage.
+
+/**
+ * Domain string — bare hostname like "acme.com" (no protocol, no leading @).
+ * Matched against the suffix of party emailAddress values.
+ */
+export const domainSchema = z
+	.string()
+	.regex(
+		/^(?!:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/,
+		'Must be a bare domain like "acme.com" (no protocol, no @)',
+	);
+
+/**
+ * Reasonable cap on how many calls a single tool invocation may fetch.
+ * Pages of /v2/calls/extensive are ~100 records; default of 500 means up to
+ * 5 paginated requests per tool call. Hard ceiling 5000 to protect against
+ * runaway agent loops against the per-day API quota.
+ */
+export const maxCallsSchema = z
+	.number()
+	.int()
+	.min(1)
+	.max(5000)
+	.default(500)
+	.describe(
+		'Maximum number of calls to fetch and post-filter (default: 500, max: 5000). Each Gong API page is ~100 calls, so 500 = up to 5 paginated requests.',
+	);
+
+// --- search_calls_by_account ---
+
+/**
+ * POST /v2/calls/extensive + post-filter on parties[].emailAddress domain
+ * and (when context: "Extended" is requested) on context CRM Account objects.
+ */
+export const searchCallsByAccountRequestSchema = z
+	.object({
+		domains: z
+			.array(domainSchema)
+			.min(1, 'At least one domain is required')
+			.describe(
+				'Email domains to match against external party email addresses (e.g., ["acme.com", "acme.io"]). A call matches if any external participant has an email at one of these domains.',
+			),
+		fromDateTime: iso8601DateTimeSchema.optional(),
+		toDateTime: iso8601DateTimeSchema.optional(),
+		workspaceId: gongIdSchema.optional(),
+		primaryUserIds: z.array(gongIdSchema).optional(),
+		matchCrmAccount: z
+			.boolean()
+			.default(false)
+			.describe(
+				'Also match calls where a CRM Account context object name contains any of the domain root words. Requires CRM integration (Salesforce/HubSpot). Default false.',
+			),
+		maxCalls: maxCallsSchema.optional(),
+		cursor: cursorSchema.optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.fromDateTime && data.toDateTime) {
+				return new Date(data.fromDateTime) < new Date(data.toDateTime);
+			}
+			return true;
+		},
+		{ message: 'fromDateTime must be before toDateTime' },
+	);
+
+export type SearchCallsByAccountRequest = z.infer<
+	typeof searchCallsByAccountRequestSchema
+>;
+
+// --- search_calls_by_opportunity ---
+
+/**
+ * POST /v2/calls/extensive + post-filter on context CRM Opportunity objects.
+ * Requires Gong-CRM integration (Salesforce/HubSpot) — calls without CRM
+ * linkage will not match.
+ */
+export const searchCallsByOpportunityRequestSchema = z
+	.object({
+		opportunityIds: z
+			.array(z.string().min(1))
+			.optional()
+			.describe(
+				'CRM Opportunity IDs to match against context.objects[].objectId where objectType=Opportunity.',
+			),
+		opportunityNames: z
+			.array(z.string().min(1))
+			.optional()
+			.describe(
+				'CRM Opportunity name substrings (case-insensitive) to match against the Name field of Opportunity context objects.',
+			),
+		fromDateTime: iso8601DateTimeSchema.optional(),
+		toDateTime: iso8601DateTimeSchema.optional(),
+		workspaceId: gongIdSchema.optional(),
+		primaryUserIds: z.array(gongIdSchema).optional(),
+		maxCalls: maxCallsSchema.optional(),
+		cursor: cursorSchema.optional(),
+	})
+	.refine(
+		(data) =>
+			(data.opportunityIds && data.opportunityIds.length > 0) ||
+			(data.opportunityNames && data.opportunityNames.length > 0),
+		{
+			message:
+				'At least one of opportunityIds or opportunityNames must be provided',
+		},
+	)
+	.refine(
+		(data) => {
+			if (data.fromDateTime && data.toDateTime) {
+				return new Date(data.fromDateTime) < new Date(data.toDateTime);
+			}
+			return true;
+		},
+		{ message: 'fromDateTime must be before toDateTime' },
+	);
+
+export type SearchCallsByOpportunityRequest = z.infer<
+	typeof searchCallsByOpportunityRequestSchema
+>;
+
+// --- search_transcripts ---
+
+/**
+ * Free-text keyword scan across call transcripts within a bounded date range.
+ * Two-phase: (1) /v2/calls/extensive narrows the call set by date + optional
+ * primaryUserIds/domains, (2) /v2/calls/transcript fetches transcripts for the
+ * narrowed set and post-filters sentences containing any keyword.
+ *
+ * For known recurring terms (competitors, ESPs, key tech), prefer setting up
+ * Gong Trackers in the UI — server-side, no transcript-scan cost — and use
+ * search_calls + get_call_summary instead.
+ */
+export const searchTranscriptsRequestSchema = z
+	.object({
+		keywords: z
+			.array(z.string().min(2))
+			.min(1, 'At least one keyword is required')
+			.describe(
+				'Keywords to search for in transcript sentences (case-insensitive by default). Each keyword must be at least 2 characters.',
+			),
+		fromDateTime: iso8601DateTimeSchema.describe(
+			'REQUIRED. Start of the date window — transcript scan is expensive, so an unbounded date range is rejected.',
+		),
+		toDateTime: iso8601DateTimeSchema.describe(
+			'REQUIRED. End of the date window.',
+		),
+		primaryUserIds: z
+			.array(gongIdSchema)
+			.optional()
+			.describe(
+				'Narrow to calls hosted by these users before scanning transcripts.',
+			),
+		domains: z
+			.array(domainSchema)
+			.optional()
+			.describe(
+				'Narrow to calls with at least one external party from these email domains before scanning transcripts.',
+			),
+		workspaceId: gongIdSchema.optional(),
+		caseSensitive: z
+			.boolean()
+			.default(false)
+			.describe(
+				'If true, match keywords case-sensitively. Default false (case-insensitive).',
+			),
+		wholeWord: z
+			.boolean()
+			.default(true)
+			.describe(
+				'If true (default), match keywords as whole words only — "ai" will not match "said" or "again". Set false for substring matching.',
+			),
+		maxCalls: maxCallsSchema.optional(),
+		maxMatchesPerCall: z
+			.number()
+			.int()
+			.min(1)
+			.max(50)
+			.default(10)
+			.describe(
+				'Maximum sentence matches returned per call (default: 10) to prevent context overflow on calls with many hits.',
+			),
+	})
+	.refine(
+		(data) => new Date(data.fromDateTime) < new Date(data.toDateTime),
+		{ message: 'fromDateTime must be before toDateTime' },
+	)
+	.refine(
+		(data) => {
+			// Require additional narrowing for windows >30 days to bound cost.
+			const days =
+				(new Date(data.toDateTime).getTime() -
+					new Date(data.fromDateTime).getTime()) /
+				(1000 * 60 * 60 * 24);
+			if (days > 30) {
+				return (
+					(data.primaryUserIds && data.primaryUserIds.length > 0) ||
+					(data.domains && data.domains.length > 0)
+				);
+			}
+			return true;
+		},
+		{
+			message:
+				'For date ranges > 30 days, you must also provide primaryUserIds or domains to bound the scan.',
+		},
+	);
+
+export type SearchTranscriptsRequest = z.infer<
+	typeof searchTranscriptsRequestSchema
+>;
+
+/**
+ * A single keyword match within a call transcript.
+ */
+export interface TranscriptMatch {
+	keyword: string;
+	speakerId: string;
+	speakerName?: string;
+	speakerAffiliation?: string;
+	startTime: number;
+	snippet: string;
+}
+
+/**
+ * Per-call match results from search_transcripts.
+ */
+export interface CallTranscriptMatches {
+	callId: string;
+	callTitle?: string;
+	callStarted?: string;
+	callUrl?: string;
+	totalMatches: number;
+	matches: TranscriptMatch[];
+	truncated: boolean;
+}
+
+/**
+ * Aggregate result returned to the caller.
+ */
+export interface SearchTranscriptsResult {
+	keywords: string[];
+	callsScanned: number;
+	callsWithMatches: number;
+	totalMatches: number;
+	results: CallTranscriptMatches[];
+	limitedByMaxCalls: boolean;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -322,7 +322,9 @@ export const partySchema = z.object({
 							objectType: z.string().nullish(),
 							objectId: z.string().nullish(),
 							fields: z
-								.array(z.object({ name: z.string(), value: z.string() }))
+								.array(
+									z.object({ name: z.string(), value: z.unknown().nullish() }),
+								)
 								.nullish(),
 						}),
 					)
@@ -516,7 +518,7 @@ export const callMetadataSchema = z.object({
  */
 export const contextFieldSchema = z.object({
 	name: z.string(),
-	value: z.string(),
+	value: z.unknown().nullish(),
 });
 
 /**

--- a/test/gong-search.test.ts
+++ b/test/gong-search.test.ts
@@ -1,0 +1,619 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GongClient } from '../src/gong.js';
+
+/**
+ * Helpers for building the mocked /v2/calls/extensive response.
+ */
+function makeCall(opts: {
+	id: string;
+	title?: string;
+	started?: string;
+	parties?: Array<{
+		emailAddress?: string;
+		affiliation?: string;
+		name?: string;
+		speakerId?: string;
+	}>;
+	context?: Array<{
+		objects?: Array<{
+			objectType: string;
+			objectId?: string;
+			fields?: Array<{ name: string; value: string }>;
+		}>;
+	}>;
+}) {
+	return {
+		metaData: {
+			id: opts.id,
+			title: opts.title ?? `Call ${opts.id}`,
+			started: opts.started ?? '2024-03-15T15:00:00Z',
+			duration: 1800,
+			scope: 'External',
+		},
+		parties: opts.parties ?? null,
+		context: opts.context ?? null,
+	};
+}
+
+function makeExtensiveResponse(
+	calls: ReturnType<typeof makeCall>[],
+	cursor?: string,
+) {
+	return {
+		requestId: 'test-req',
+		records: {
+			totalRecords: calls.length,
+			currentPageSize: calls.length,
+			currentPageNumber: 1,
+			...(cursor ? { cursor } : {}),
+		},
+		calls,
+	};
+}
+
+describe('GongClient — search_calls_by_account', () => {
+	let client: GongClient;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		global.fetch = fetchMock;
+		client = new GongClient({
+			accessKey: 'k',
+			accessKeySecret: 's',
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('matches calls where any party email is at the target domain', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [{ emailAddress: 'rep@gong.io' }],
+					}),
+					makeCall({
+						id: '2',
+						parties: [
+							{ emailAddress: 'rep@gong.io' },
+							{ emailAddress: 'buyer@acme.com' },
+						],
+					}),
+					makeCall({
+						id: '3',
+						parties: [{ emailAddress: 'noone@other.com' }],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+		});
+
+		expect(result.matched).toBe(1);
+		expect(result.calls[0]?.metaData.id).toBe('2');
+		expect(result.totalScanned).toBe(3);
+		expect(result.limitedByMaxCalls).toBe(false);
+	});
+
+	it('matches case-insensitively and handles multiple domains', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [{ emailAddress: 'BUYER@ACME.COM' }],
+					}),
+					makeCall({
+						id: '2',
+						parties: [{ emailAddress: 'lead@acme.io' }],
+					}),
+					makeCall({
+						id: '3',
+						parties: [{ emailAddress: 'noone@beta.com' }],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com', 'acme.io'],
+		});
+
+		expect(result.matched).toBe(2);
+		const ids = result.calls.map((c) => c.metaData.id).sort();
+		expect(ids).toEqual(['1', '2']);
+	});
+
+	it('does not match a domain that is a substring of another (no false positives)', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					// "macme.com" should NOT match "acme.com"
+					makeCall({
+						id: '1',
+						parties: [{ emailAddress: 'rep@macme.com' }],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+		});
+
+		expect(result.matched).toBe(0);
+	});
+
+	it('only consults CRM Account context when matchCrmAccount=true', async () => {
+		const callWithCrm = makeCall({
+			id: '1',
+			parties: [{ emailAddress: 'rep@vendor.com' }],
+			context: [
+				{
+					objects: [
+						{
+							objectType: 'Account',
+							fields: [{ name: 'Name', value: 'Acme Industries' }],
+						},
+					],
+				},
+			],
+		});
+
+		// First call: matchCrmAccount=false → no match
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => makeExtensiveResponse([callWithCrm]),
+		});
+		const off = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+		});
+		expect(off.matched).toBe(0);
+
+		// Second call: matchCrmAccount=true → matches via "Acme Industries" name
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => makeExtensiveResponse([callWithCrm]),
+		});
+		const on = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+			matchCrmAccount: true,
+		});
+		expect(on.matched).toBe(1);
+	});
+
+	it('auto-paginates until maxCalls is reached', async () => {
+		const page1 = makeExtensiveResponse(
+			Array.from({ length: 3 }, (_, i) =>
+				makeCall({
+					id: `${i + 1}`,
+					parties: [{ emailAddress: `b${i}@acme.com` }],
+				}),
+			),
+			'cursor-2',
+		);
+		const page2 = makeExtensiveResponse(
+			Array.from({ length: 3 }, (_, i) =>
+				makeCall({
+					id: `${i + 4}`,
+					parties: [{ emailAddress: `b${i + 3}@acme.com` }],
+				}),
+			),
+		);
+
+		fetchMock
+			.mockResolvedValueOnce({ ok: true, json: async () => page1 })
+			.mockResolvedValueOnce({ ok: true, json: async () => page2 });
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+			maxCalls: 10,
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.matched).toBe(6);
+		expect(result.limitedByMaxCalls).toBe(false);
+	});
+
+	it('flags limitedByMaxCalls when cap is hit', async () => {
+		const page = makeExtensiveResponse(
+			Array.from({ length: 3 }, (_, i) =>
+				makeCall({
+					id: `${i + 1}`,
+					parties: [{ emailAddress: `b${i}@acme.com` }],
+				}),
+			),
+			'cursor-2',
+		);
+		fetchMock.mockResolvedValueOnce({ ok: true, json: async () => page });
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+			maxCalls: 2,
+		});
+
+		expect(result.limitedByMaxCalls).toBe(true);
+		expect(result.calls).toHaveLength(2);
+	});
+});
+
+describe('GongClient — search_calls_by_opportunity', () => {
+	let client: GongClient;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		global.fetch = fetchMock;
+		client = new GongClient({ accessKey: 'k', accessKeySecret: 's' });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('matches by opportunityId in CRM context', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						context: [
+							{
+								objects: [
+									{ objectType: 'Account', objectId: 'A1' },
+									{ objectType: 'Opportunity', objectId: 'OPP-100' },
+								],
+							},
+						],
+					}),
+					makeCall({
+						id: '2',
+						context: [
+							{
+								objects: [
+									{ objectType: 'Opportunity', objectId: 'OPP-999' },
+								],
+							},
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByOpportunity({
+			opportunityIds: ['OPP-100'],
+		});
+		expect(result.matched).toBe(1);
+		expect(result.calls[0]?.metaData.id).toBe('1');
+	});
+
+	it('matches by opportunityName substring (case-insensitive)', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						context: [
+							{
+								objects: [
+									{
+										objectType: 'Opportunity',
+										fields: [{ name: 'Name', value: 'Acme Q4 Renewal' }],
+									},
+								],
+							},
+						],
+					}),
+					makeCall({
+						id: '2',
+						context: [
+							{
+								objects: [
+									{
+										objectType: 'Opportunity',
+										fields: [{ name: 'Name', value: 'Beta Expansion' }],
+									},
+								],
+							},
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByOpportunity({
+			opportunityNames: ['acme'],
+		});
+		expect(result.matched).toBe(1);
+		expect(result.calls[0]?.metaData.id).toBe('1');
+	});
+
+	it('does not match Account context objects (only Opportunity)', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						context: [
+							{
+								objects: [
+									{
+										objectType: 'Account',
+										fields: [{ name: 'Name', value: 'Acme Inc.' }],
+									},
+								],
+							},
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByOpportunity({
+			opportunityNames: ['acme'],
+		});
+		expect(result.matched).toBe(0);
+	});
+});
+
+describe('GongClient — search_transcripts', () => {
+	let client: GongClient;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		global.fetch = fetchMock;
+		client = new GongClient({ accessKey: 'k', accessKeySecret: 's' });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function transcriptsResponse(
+		entries: Array<{
+			callId: string;
+			speakerId: string;
+			sentences: Array<{ start: number; end: number; text: string }>;
+		}>,
+	) {
+		// group by callId
+		const byCall = new Map<
+			string,
+			Array<{
+				speakerId: string;
+				sentences: Array<{ start: number; end: number; text: string }>;
+			}>
+		>();
+		for (const e of entries) {
+			const arr = byCall.get(e.callId) ?? [];
+			arr.push({ speakerId: e.speakerId, sentences: e.sentences });
+			byCall.set(e.callId, arr);
+		}
+		return {
+			requestId: 't',
+			records: {
+				totalRecords: byCall.size,
+				currentPageSize: byCall.size,
+				currentPageNumber: 1,
+			},
+			callTranscripts: Array.from(byCall.entries()).map(
+				([callId, transcript]) => ({ callId, transcript }),
+			),
+		};
+	}
+
+	it('finds whole-word case-insensitive matches by default', async () => {
+		// Phase 1: extensive
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [
+							{
+								speakerId: 'spk-a',
+								name: 'Rep A',
+								affiliation: 'Internal',
+							},
+							{
+								speakerId: 'spk-b',
+								name: 'Buyer B',
+								affiliation: 'External',
+							},
+						],
+					}),
+				]),
+		});
+		// Phase 2: transcript
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				transcriptsResponse([
+					{
+						callId: '1',
+						speakerId: 'spk-b',
+						sentences: [
+							{
+								start: 1000,
+								end: 5000,
+								text: "We're evaluating Braze right now.",
+							},
+							{ start: 5500, end: 7000, text: 'It looks promising.' },
+						],
+					},
+					{
+						callId: '1',
+						speakerId: 'spk-a',
+						sentences: [
+							{
+								start: 8000,
+								end: 12000,
+								text: "Embraced by enterprise customers", // contains "raced" but not whole word "braze"
+							},
+						],
+					},
+				]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['braze'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+			wholeWord: true,
+			caseSensitive: false,
+		});
+
+		expect(result.callsScanned).toBe(1);
+		expect(result.callsWithMatches).toBe(1);
+		expect(result.totalMatches).toBe(1);
+		const match = result.results[0]?.matches[0];
+		expect(match?.keyword).toBe('braze');
+		expect(match?.speakerName).toBe('Buyer B');
+		expect(match?.speakerAffiliation).toBe('External');
+	});
+
+	it('respects wholeWord=false (substring match)', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [{ speakerId: 'spk-a', name: 'Rep' }],
+					}),
+				]),
+		});
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				transcriptsResponse([
+					{
+						callId: '1',
+						speakerId: 'spk-a',
+						sentences: [
+							{
+								start: 1000,
+								end: 5000,
+								text: 'embraced by enterprise customers',
+							},
+						],
+					},
+				]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['brace'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+			wholeWord: false,
+		});
+
+		expect(result.totalMatches).toBe(1);
+	});
+
+	it('narrows by domain before scanning transcripts', async () => {
+		// Phase 1 returns 2 calls; only one has a party at acme.com
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [{ speakerId: 'spk', emailAddress: 'b@acme.com' }],
+					}),
+					makeCall({
+						id: '2',
+						parties: [{ speakerId: 'spk', emailAddress: 'b@beta.com' }],
+					}),
+				]),
+		});
+		// Phase 2 should only be called for callId 1
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				transcriptsResponse([
+					{
+						callId: '1',
+						speakerId: 'spk',
+						sentences: [
+							{ start: 0, end: 1000, text: 'Klaviyo is our current ESP.' },
+						],
+					},
+				]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['klaviyo'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+			domains: ['acme.com'],
+		});
+
+		expect(result.callsScanned).toBe(1);
+		expect(result.callsWithMatches).toBe(1);
+
+		// Verify the transcript request only contained callId 1
+		const transcriptCall = fetchMock.mock.calls[1];
+		const body = JSON.parse(transcriptCall?.[1].body);
+		expect(body.filter.callIds).toEqual(['1']);
+	});
+
+	it('truncates matches at maxMatchesPerCall', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [{ speakerId: 'spk', name: 'Rep' }],
+					}),
+				]),
+		});
+		const sentences = Array.from({ length: 10 }, (_, i) => ({
+			start: i * 1000,
+			end: (i + 1) * 1000,
+			text: `klaviyo mention ${i}`,
+		}));
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				transcriptsResponse([{ callId: '1', speakerId: 'spk', sentences }]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['klaviyo'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+			maxMatchesPerCall: 3,
+		});
+
+		expect(result.totalMatches).toBe(3);
+		expect(result.results[0]?.truncated).toBe(true);
+	});
+
+	it('returns zero results when phase 1 narrows everything out', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => makeExtensiveResponse([]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['anything'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+		});
+
+		expect(result.callsScanned).toBe(0);
+		expect(result.totalMatches).toBe(0);
+		// Should not have called the transcripts endpoint
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/gong-search.test.ts
+++ b/test/gong-search.test.ts
@@ -18,7 +18,7 @@ function makeCall(opts: {
 		objects?: Array<{
 			objectType: string;
 			objectId?: string;
-			fields?: Array<{ name: string; value: string }>;
+			fields?: Array<{ name: string; value: unknown }>;
 		}>;
 	}>;
 }) {
@@ -68,25 +68,29 @@ describe('GongClient — search_calls_by_account', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('matches calls where any party email is at the target domain', async () => {
+	it('matches calls where any external party email is at the target domain', async () => {
 		fetchMock.mockResolvedValueOnce({
 			ok: true,
 			json: async () =>
 				makeExtensiveResponse([
 					makeCall({
 						id: '1',
-						parties: [{ emailAddress: 'rep@gong.io' }],
+						parties: [
+							{ emailAddress: 'rep@gong.io', affiliation: 'Internal' },
+						],
 					}),
 					makeCall({
 						id: '2',
 						parties: [
-							{ emailAddress: 'rep@gong.io' },
-							{ emailAddress: 'buyer@acme.com' },
+							{ emailAddress: 'rep@gong.io', affiliation: 'Internal' },
+							{ emailAddress: 'buyer@acme.com', affiliation: 'External' },
 						],
 					}),
 					makeCall({
 						id: '3',
-						parties: [{ emailAddress: 'noone@other.com' }],
+						parties: [
+							{ emailAddress: 'noone@other.com', affiliation: 'External' },
+						],
 					}),
 				]),
 		});
@@ -101,6 +105,28 @@ describe('GongClient — search_calls_by_account', () => {
 		expect(result.limitedByMaxCalls).toBe(false);
 	});
 
+	it('does not match internal participants at the target domain', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [
+							{ emailAddress: 'rep@acme.com', affiliation: 'Internal' },
+							{ emailAddress: 'buyer@other.com', affiliation: 'External' },
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByAccount({
+			domains: ['acme.com'],
+		});
+
+		expect(result.matched).toBe(0);
+	});
+
 	it('matches case-insensitively and handles multiple domains', async () => {
 		fetchMock.mockResolvedValueOnce({
 			ok: true,
@@ -108,15 +134,21 @@ describe('GongClient — search_calls_by_account', () => {
 				makeExtensiveResponse([
 					makeCall({
 						id: '1',
-						parties: [{ emailAddress: 'BUYER@ACME.COM' }],
+						parties: [
+							{ emailAddress: 'BUYER@ACME.COM', affiliation: 'External' },
+						],
 					}),
 					makeCall({
 						id: '2',
-						parties: [{ emailAddress: 'lead@acme.io' }],
+						parties: [
+							{ emailAddress: 'lead@acme.io', affiliation: 'External' },
+						],
 					}),
 					makeCall({
 						id: '3',
-						parties: [{ emailAddress: 'noone@beta.com' }],
+						parties: [
+							{ emailAddress: 'noone@beta.com', affiliation: 'External' },
+						],
 					}),
 				]),
 		});
@@ -138,7 +170,9 @@ describe('GongClient — search_calls_by_account', () => {
 					// "macme.com" should NOT match "acme.com"
 					makeCall({
 						id: '1',
-						parties: [{ emailAddress: 'rep@macme.com' }],
+						parties: [
+							{ emailAddress: 'rep@macme.com', affiliation: 'External' },
+						],
 					}),
 				]),
 		});
@@ -193,7 +227,9 @@ describe('GongClient — search_calls_by_account', () => {
 			Array.from({ length: 3 }, (_, i) =>
 				makeCall({
 					id: `${i + 1}`,
-					parties: [{ emailAddress: `b${i}@acme.com` }],
+					parties: [
+						{ emailAddress: `b${i}@acme.com`, affiliation: 'External' },
+					],
 				}),
 			),
 			'cursor-2',
@@ -202,7 +238,12 @@ describe('GongClient — search_calls_by_account', () => {
 			Array.from({ length: 3 }, (_, i) =>
 				makeCall({
 					id: `${i + 4}`,
-					parties: [{ emailAddress: `b${i + 3}@acme.com` }],
+					parties: [
+						{
+							emailAddress: `b${i + 3}@acme.com`,
+							affiliation: 'External',
+						},
+					],
 				}),
 			),
 		);
@@ -226,7 +267,9 @@ describe('GongClient — search_calls_by_account', () => {
 			Array.from({ length: 3 }, (_, i) =>
 				makeCall({
 					id: `${i + 1}`,
-					parties: [{ emailAddress: `b${i}@acme.com` }],
+					parties: [
+						{ emailAddress: `b${i}@acme.com`, affiliation: 'External' },
+					],
 				}),
 			),
 			'cursor-2',
@@ -319,6 +362,54 @@ describe('GongClient — search_calls_by_opportunity', () => {
 									{
 										objectType: 'Opportunity',
 										fields: [{ name: 'Name', value: 'Beta Expansion' }],
+									},
+								],
+							},
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchCallsByOpportunity({
+			opportunityNames: ['acme'],
+		});
+		expect(result.matched).toBe(1);
+		expect(result.calls[0]?.metaData.id).toBe('1');
+	});
+
+	it('ignores non-string CRM fields while matching opportunity names', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						context: [
+							{
+								objects: [
+									{
+										objectType: 'Opportunity',
+										fields: [
+											{ name: 'Name', value: 'Acme Q4 Renewal' },
+											{ name: 'Amount', value: 250000 },
+											{ name: 'Probability', value: 0.8 },
+										],
+									},
+								],
+							},
+						],
+					}),
+					makeCall({
+						id: '2',
+						context: [
+							{
+								objects: [
+									{
+										objectType: 'Opportunity',
+										fields: [
+											{ name: 'Name', value: 12345 },
+											{ name: 'Amount', value: 50000 },
+										],
 									},
 								],
 							},
@@ -527,11 +618,23 @@ describe('GongClient — search_transcripts', () => {
 				makeExtensiveResponse([
 					makeCall({
 						id: '1',
-						parties: [{ speakerId: 'spk', emailAddress: 'b@acme.com' }],
+						parties: [
+							{
+								speakerId: 'spk',
+								emailAddress: 'b@acme.com',
+								affiliation: 'External',
+							},
+						],
 					}),
 					makeCall({
 						id: '2',
-						parties: [{ speakerId: 'spk', emailAddress: 'b@beta.com' }],
+						parties: [
+							{
+								speakerId: 'spk',
+								emailAddress: 'b@beta.com',
+								affiliation: 'External',
+							},
+						],
 					}),
 				]),
 		});
@@ -564,6 +667,41 @@ describe('GongClient — search_transcripts', () => {
 		const transcriptCall = fetchMock.mock.calls[1];
 		const body = JSON.parse(transcriptCall?.[1].body);
 		expect(body.filter.callIds).toEqual(['1']);
+	});
+
+	it('does not use internal participants for transcript domain narrowing', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () =>
+				makeExtensiveResponse([
+					makeCall({
+						id: '1',
+						parties: [
+							{
+								speakerId: 'rep',
+								emailAddress: 'rep@acme.com',
+								affiliation: 'Internal',
+							},
+							{
+								speakerId: 'buyer',
+								emailAddress: 'buyer@other.com',
+								affiliation: 'External',
+							},
+						],
+					}),
+				]),
+		});
+
+		const result = await client.searchTranscripts({
+			keywords: ['klaviyo'],
+			fromDateTime: '2024-03-01T00:00:00Z',
+			toDateTime: '2024-03-15T00:00:00Z',
+			domains: ['acme.com'],
+		});
+
+		expect(result.callsScanned).toBe(0);
+		expect(result.totalMatches).toBe(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('truncates matches at maxMatchesPerCall', async () => {

--- a/test/schemas-search.test.ts
+++ b/test/schemas-search.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+	searchCallsByAccountRequestSchema,
+	searchCallsByOpportunityRequestSchema,
+	searchTranscriptsRequestSchema,
+} from '../src/schemas.js';
+
+describe('searchCallsByAccountRequestSchema', () => {
+	it('accepts a single domain', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['acme.com'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts multiple domains', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['acme.com', 'acme.io', 'sub.acme.com'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('requires at least one domain', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: [],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects domains with protocol', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['https://acme.com'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects email-like input', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['user@acme.com'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects bare hostnames without TLD', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['localhost'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('honors fromDateTime < toDateTime check', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['acme.com'],
+			fromDateTime: '2024-12-31T23:59:59Z',
+			toDateTime: '2024-01-01T00:00:00Z',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('caps maxCalls at 5000', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['acme.com'],
+			maxCalls: 9999,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts matchCrmAccount flag', () => {
+		const result = searchCallsByAccountRequestSchema.safeParse({
+			domains: ['acme.com'],
+			matchCrmAccount: true,
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('searchCallsByOpportunityRequestSchema', () => {
+	it('accepts opportunityIds only', () => {
+		const result = searchCallsByOpportunityRequestSchema.safeParse({
+			opportunityIds: ['006abc', '006def'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts opportunityNames only', () => {
+		const result = searchCallsByOpportunityRequestSchema.safeParse({
+			opportunityNames: ['Acme Q4'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts both', () => {
+		const result = searchCallsByOpportunityRequestSchema.safeParse({
+			opportunityIds: ['006abc'],
+			opportunityNames: ['Acme'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects when neither is provided', () => {
+		const result = searchCallsByOpportunityRequestSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects empty arrays', () => {
+		const result = searchCallsByOpportunityRequestSchema.safeParse({
+			opportunityIds: [],
+			opportunityNames: [],
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('searchTranscriptsRequestSchema', () => {
+	const baseInput = {
+		keywords: ['braze'],
+		fromDateTime: '2024-03-01T00:00:00Z',
+		toDateTime: '2024-03-15T00:00:00Z',
+	};
+
+	it('accepts a minimal valid request (<30 day window)', () => {
+		const result = searchTranscriptsRequestSchema.safeParse(baseInput);
+		expect(result.success).toBe(true);
+	});
+
+	it('requires keywords', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			...baseInput,
+			keywords: [],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects 1-character keywords', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			...baseInput,
+			keywords: ['a'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('requires fromDateTime', () => {
+		const { fromDateTime: _, ...rest } = baseInput;
+		const result = searchTranscriptsRequestSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+
+	it('requires toDateTime', () => {
+		const { toDateTime: _, ...rest } = baseInput;
+		const result = searchTranscriptsRequestSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects >30-day window with no narrowing filters', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			keywords: ['braze'],
+			fromDateTime: '2024-01-01T00:00:00Z',
+			toDateTime: '2024-06-01T00:00:00Z',
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts >30-day window when primaryUserIds is provided', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			keywords: ['braze'],
+			fromDateTime: '2024-01-01T00:00:00Z',
+			toDateTime: '2024-06-01T00:00:00Z',
+			primaryUserIds: ['111'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts >30-day window when domains is provided', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			keywords: ['braze'],
+			fromDateTime: '2024-01-01T00:00:00Z',
+			toDateTime: '2024-06-01T00:00:00Z',
+			domains: ['acme.com'],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects >30-day window with empty narrowing arrays', () => {
+		const result = searchTranscriptsRequestSchema.safeParse({
+			keywords: ['braze'],
+			fromDateTime: '2024-01-01T00:00:00Z',
+			toDateTime: '2024-06-01T00:00:00Z',
+			primaryUserIds: [],
+			domains: [],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('defaults wholeWord to true and caseSensitive to false', () => {
+		const result = searchTranscriptsRequestSchema.safeParse(baseInput);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.wholeWord).toBe(true);
+			expect(result.data.caseSensitive).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
# feat: add `search_calls_by_account`, `search_calls_by_opportunity`, `search_transcripts`

## Summary

Three new tools for use cases the Gong API does not expose as server-side filters. All three wrap `POST /v2/calls/extensive` with a richer `contentSelector` (parties + Extended context) and post-filter the response, with auto-pagination and configurable cost ceilings.

| Tool | Solves |
|---|---|
| `search_calls_by_account` | Filter calls by account/company via external participant email domains. Optional CRM Account name match. |
| `search_calls_by_opportunity` | Filter calls linked to specific CRM Opportunity IDs or Name substrings (requires Gong–CRM integration). |
| `search_transcripts` | Free-text keyword search across transcript sentences in a bounded date window. |

## Why

These have come up repeatedly in the Gong developer community — the [account-name filter gap](https://visioneers.gong.io/data-in-gong-71) is the most-cited pain point. Each of the three tools handles a real-world filter shape that `/v2/calls/extensive` cannot do natively:

- **Account/company** — The Gong API has no native account-name filter. The community's documented workaround is to match email domains in `parties[].emailAddress`. This tool encapsulates that pattern, plus an opt-in CRM Account context-object name match.
- **Opportunity** — `context.objects[]` from `/v2/calls/extensive` with `context: "Extended"` does include linked Opportunities for CRM-integrated calls, but you have to manually post-filter. This tool does it for you.
- **Free-text keywords** — There is no transcript-search endpoint. The two-phase fetch-then-grep pattern is the only path. This tool bakes in cost guards (date window > 30 days requires user/domain narrowing) and a per-call match cap to prevent context overflow on chatty calls.

## What's in the PR

**Code (`src/`)**
- `schemas.ts` — three new Zod request schemas + result interfaces. New shared bits: `domainSchema` (bare-hostname validator), `maxCallsSchema` (1–5000, default 500).
- `gong.ts` — three new client methods, plus a private `fetchCallsExtensiveWithContext` helper that auto-paginates `/v2/calls/extensive` with parties + Extended context. 50-page hard ceiling as runaway-loop defense.
- `formatters.ts` — `formatMatchedCalls` (used by account & opportunity, shows matching external parties) and `formatTranscriptMatches` (sentence-level snippets with speaker name, affiliation, and mm:ss timestamp).
- `index.ts` — three new tool definitions in `ListToolsRequestSchema`, three new case branches in the call handler.

**Tests (`test/`)**
- `schemas-search.test.ts` — 24 tests covering schema validation including the 30-day cost-guard refinement.
- `gong-search.test.ts` — 14 tests with mocked fetch covering post-filter correctness, auto-pagination, the `limitedByMaxCalls` flag, and verification that phase-1 narrowing actually reduces phase-2 fetches.

**Docs**
- `README.md` — quick-reference table updated, three detailed `<details>`-collapsed tool sections following the existing pattern, three new example prompts.

## Correctness invariants pinned by tests

- `"macme.com"` does **not** match domain `"acme.com"` — the suffix anchor is `@<domain>`, not just substring.
- `"embraced"` does **not** match keyword `"braze"` — whole-word matching is the default.
- Opportunity post-filter reads only `context.objects[]` where `objectType === "Opportunity"`, never bleeds into Account context objects.
- `search_transcripts` `domains` filter narrows the call set **before** the transcript fan-out — the test asserts the second `fetch` call body's `filter.callIds` is the narrowed set, not the full date-range set.

## Cost profile

| Tool | Typical cost (90-day window, no narrowing) |
|---|---|
| `search_calls_by_account` | 1–5 paginated `/v2/calls/extensive` requests |
| `search_calls_by_opportunity` | Same — CRM context rides on the same response |
| `search_transcripts` | 1–5 extensive + 1 transcript request per ~100 narrowed calls (batched) |

For known recurring keyword search needs (competitor names, ESP/tech terms), the README explicitly steers users toward Gong Trackers + `get_call_summary` instead of `search_transcripts`. Trackers are server-side and dramatically cheaper.

## Verification

- `npm test` — 193 passing (155 baseline + 38 new), 0 failing
- `npm run typecheck` — clean
- `npm run lint` — clean (one pre-existing biome-version info notice, unchanged from main)
- `npm run validate:mcp` — passing
- `npm run build` — succeeds
- Smoke-tested: `node dist/index.js` boots and emits `Gong MCP server running on stdio`

## Open questions for you

1. **Versioning:** This is a `feat:` so release-please will bump minor. Any preference on splitting into 3 separate `feat:` commits (one per tool) for cleaner CHANGELOG entries? I kept it as one commit because the three tools share `fetchCallsExtensiveWithContext` and `formatMatchedCalls` infrastructure, but I'm happy to rebase-split if you'd prefer 3 minor bumps over 1.
2. **CRM Account match default:** I left `matchCrmAccount` defaulting to `false` because CRM context is only populated when Gong–CRM integration is configured, and silently matching CRM names by domain root could surprise users who don't have CRM hooked up. Happy to flip the default if you'd rather it be on.
3. **`maxCalls` default:** I set 500 (≈5 pages). If you'd prefer a lower default to be more conservative, let me know.

Happy to iterate on naming, defaults, or split into smaller PRs.
