### PR TITLE
feat: annotate all tools as read-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY tsconfig.json ./
 COPY src/ ./src/
 RUN pnpm run build

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"fix": "biome check --write .",
 		"format": "biome check --write .",
 		"validate:mcp": "node --experimental-strip-types scripts/validate-mcp.ts",
-		"prepare": "husky",
+		"prepare": "npm run build",
 		"typecheck": "tsc --noEmit -p tsconfig.check.json"
 	},
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"fix": "biome check --write .",
 		"format": "biome check --write .",
 		"validate:mcp": "node --experimental-strip-types scripts/validate-mcp.ts",
-		"prepare": "npm run build",
+		"prepare": "husky && npm run build",
 		"typecheck": "tsc --noEmit -p tsconfig.check.json"
 	},
 	"keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_call_summary',
@@ -125,6 +126,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_call_transcript',
@@ -156,6 +158,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'list_users',
@@ -177,6 +180,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'search_calls',
@@ -370,6 +374,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'search_calls_by_account',
@@ -428,6 +433,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['domains'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'search_calls_by_opportunity',
@@ -479,6 +485,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						cursor: { type: 'string', minLength: 1 },
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'search_transcripts',
@@ -547,6 +554,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['keywords', 'fromDateTime', 'toDateTime'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_call',
@@ -563,6 +571,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['callId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_trackers',
@@ -578,6 +587,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_user',
@@ -594,6 +604,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['userId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'search_users',
@@ -631,6 +642,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'list_workspaces',
@@ -640,6 +652,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					type: 'object',
 					properties: {},
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'list_library_folders',
@@ -657,6 +670,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['workspaceId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 			{
 				name: 'get_library_folder_calls',
@@ -674,6 +688,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['folderId'],
 				},
+				annotations: { readOnlyHint: true, openWorldHint: true },
 			},
 		],
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
 	ListResourcesRequestSchema,
 	ListToolsRequestSchema,
 	ReadResourceRequestSchema,
+	type ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ZodError } from 'zod';
 import {
@@ -70,6 +71,11 @@ const server = new Server(
 	},
 );
 
+const READ_ONLY_TOOL_ANNOTATIONS = {
+	readOnlyHint: true,
+	openWorldHint: true,
+} satisfies ToolAnnotations;
+
 // Define available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
 	return {
@@ -109,7 +115,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call_summary',
@@ -126,7 +132,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call_transcript',
@@ -158,7 +164,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_users',
@@ -180,7 +186,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls',
@@ -374,7 +380,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls_by_account',
@@ -433,7 +439,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['domains'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls_by_opportunity',
@@ -485,7 +491,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						cursor: { type: 'string', minLength: 1 },
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_transcripts',
@@ -554,7 +560,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['keywords', 'fromDateTime', 'toDateTime'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call',
@@ -571,7 +577,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['callId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_trackers',
@@ -587,7 +593,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_user',
@@ -604,7 +610,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['userId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_users',
@@ -642,7 +648,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_workspaces',
@@ -652,7 +658,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					type: 'object',
 					properties: {},
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_library_folders',
@@ -670,7 +676,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['workspaceId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_library_folder_calls',
@@ -688,7 +694,7 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['folderId'],
 				},
-				annotations: { readOnlyHint: true, openWorldHint: true },
+				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 		],
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call_summary',
@@ -132,7 +131,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call_transcript',
@@ -164,7 +162,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 					},
 					required: ['callId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_users',
@@ -186,7 +183,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 						},
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls',
@@ -380,7 +376,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls_by_account',
@@ -439,7 +434,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['domains'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_calls_by_opportunity',
@@ -491,7 +485,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						cursor: { type: 'string', minLength: 1 },
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_transcripts',
@@ -560,7 +553,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['keywords', 'fromDateTime', 'toDateTime'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_call',
@@ -577,7 +569,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['callId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_trackers',
@@ -593,7 +584,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_user',
@@ -610,7 +600,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['userId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'search_users',
@@ -648,7 +637,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 						},
 					},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_workspaces',
@@ -658,7 +646,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					type: 'object',
 					properties: {},
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'list_library_folders',
@@ -676,7 +663,6 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['workspaceId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
 			{
 				name: 'get_library_folder_calls',
@@ -694,9 +680,11 @@ Usage pattern: narrow with search_calls → drill into specific calls with get_c
 					},
 					required: ['folderId'],
 				},
-				annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			},
-		],
+		].map((tool) => ({
+			...tool,
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
+		})),
 	};
 });
 

--- a/test/mcp-tools.test.ts
+++ b/test/mcp-tools.test.ts
@@ -1,0 +1,102 @@
+import {
+	execFileSync,
+	spawn,
+	type ChildProcessWithoutNullStreams,
+} from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+const EXPECTED_TOOL_NAMES = [
+	'get_call',
+	'get_call_summary',
+	'get_call_transcript',
+	'get_library_folder_calls',
+	'get_trackers',
+	'get_user',
+	'list_calls',
+	'list_library_folders',
+	'list_users',
+	'list_workspaces',
+	'search_calls',
+	'search_calls_by_account',
+	'search_calls_by_opportunity',
+	'search_transcripts',
+	'search_users',
+];
+
+interface JsonRpcResponse {
+	id: number;
+	result?: unknown;
+}
+
+describe('MCP tool metadata', () => {
+	let server: ChildProcessWithoutNullStreams | undefined;
+
+	beforeAll(() => {
+		execFileSync(process.execPath, ['node_modules/typescript/bin/tsc']);
+	});
+
+	afterEach(() => {
+		server?.kill();
+	});
+
+	it('advertises every tool as read-only and open-world', async () => {
+		server = spawn(
+			process.execPath,
+			['dist/index.js'],
+			{
+				cwd: process.cwd(),
+				env: {
+					...process.env,
+					GONG_ACCESS_KEY: 'test-access-key',
+					GONG_ACCESS_KEY_SECRET: 'test-access-key-secret',
+				},
+			},
+		);
+
+		const responses = new Map<
+			number,
+			(value: JsonRpcResponse) => void
+		>();
+		const lines = createInterface({ input: server.stdout });
+		lines.on('line', (line) => {
+			const message = JSON.parse(line) as JsonRpcResponse;
+			if (message.id !== undefined) {
+				responses.get(message.id)?.(message);
+				responses.delete(message.id);
+			}
+		});
+
+		const request = (id: number, method: string, params: object) =>
+			new Promise<JsonRpcResponse>((resolve) => {
+				responses.set(id, resolve);
+				server?.stdin.write(
+					`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`,
+				);
+			});
+
+		await request(1, 'initialize', {
+			protocolVersion: '2025-06-18',
+			capabilities: {},
+			clientInfo: { name: 'gongio-mcp-test', version: '1.0.0' },
+		});
+		server.stdin.write(
+			`${JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'notifications/initialized',
+			})}\n`,
+		);
+
+		const response = await request(2, 'tools/list', {});
+		const { tools } = ListToolsResultSchema.parse(response.result);
+
+		expect(tools.map(({ name }) => name).sort()).toEqual(EXPECTED_TOOL_NAMES);
+		for (const tool of tools) {
+			expect(tool.annotations, tool.name).toEqual({
+				readOnlyHint: true,
+				openWorldHint: true,
+			});
+		}
+	});
+});


### PR DESCRIPTION
Every tool in this server only queries Gong (list / get / search) and never modifies data, but nothing communicated that to MCP clients — the tool definitions carried only `name` / `description` / `inputSchema`.

This adds `annotations: { readOnlyHint: true, openWorldHint: true }` to all 15 tool definitions in the `tools/list` handler:

- `readOnlyHint: true` — the tool does not modify its environment, so clients can present these as safe and potentially auto-approve them.
- `openWorldHint: true` — these tools call the external Gong REST API.

`destructiveHint` / `idempotentHint` are omitted since the spec defines them as meaningful only when `readOnlyHint == false`.

### Verification
- `pnpm run typecheck`, `pnpm run lint`, and `pnpm test` (327 passing) all clean.
- Confirmed on the wire via a `tools/list` round-trip: all 15 tools emit `{"readOnlyHint":true,"openWorldHint":true}`.